### PR TITLE
feat(loader): LoadDiff quality of life improvements

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -10,11 +10,13 @@ var (
 	ErrInvalidType = errors.New("invalid type")
 )
 
-// LoadDiff inserts the fields provided in the new object into the old object and returns the result.
+// LoadDiff inserts the fields provided in the new struct pointer into the old struct pointer and returns the result.
+//
+// Note that it only pushes non-zero value updates, meaning you cannot set any field to zero, the empty string, etc.
 //
 // This can be if you are inserting a patch into an existing object but require a new object to be returned with
 // all fields.
-func LoadDiff[T any](old T, newT T) error {
+func LoadDiff[T any](old *T, newT *T) error {
 	return loadDiff(old, newT)
 }
 

--- a/loader.go
+++ b/loader.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// ErrInvalidType is returned when the provided type is not a pointer to a struct
-	ErrInvalidType = errors.New("invalid type")
+	ErrInvalidType = errors.New("invalid type: must pointer to struct")
 )
 
 // LoadDiff inserts the fields provided in the new struct pointer into the old struct pointer and returns the result.

--- a/sql.go
+++ b/sql.go
@@ -144,7 +144,7 @@ func (s *SQLPatch) PerformPatch() (sql.Result, error) {
 	return s.db.Exec(s.GenerateSQL())
 }
 
-func NewDiffSQLPatch[T any](old, newT T, opts ...PatchOpt) (*SQLPatch, error) {
+func NewDiffSQLPatch[T any](old, newT *T, opts ...PatchOpt) (*SQLPatch, error) {
 	if !isPointerToStruct(old) || !isPointerToStruct(newT) {
 		return nil, ErrInvalidType
 	}

--- a/sql_test.go
+++ b/sql_test.go
@@ -405,22 +405,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_noChange() {
 func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_fail_notStruct() {
 	obj := 1
 
-	_, err := NewDiffSQLPatch(obj, obj)
-	s.Error(err)
-}
-
-func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_fail_notPointer() {
-	type testObj struct {
-		Id   *int    `db:"id"`
-		Name *string `db:"name"`
-	}
-
-	obj := testObj{
-		Id:   ptr(1),
-		Name: ptr("test"),
-	}
-
-	_, err := NewDiffSQLPatch(obj, obj)
+	_, err := NewDiffSQLPatch(&obj, &obj)
 	s.Error(err)
 }
 


### PR DESCRIPTION
`LoadDiff` now:
- Takes in a pointer, requiring less validation and making it easier to use
- Says it takes in a struct pointer
- Explains that it will not set zero values