### PR TITLE
fix(loader): Correcting how we compare for nil values

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -108,9 +108,9 @@ func (l *loader) loadDiff(old, newT any) error {
 		// Compare the old and new fields.
 		//
 		// New fields take priority over old fields if they are provided based on the configuration.
-		if !nElem.Field(i).IsZero() || l.includeZeroValues {
+		if nElem.Field(i).Kind() != reflect.Ptr && (!nElem.Field(i).IsZero() || l.includeZeroValues) {
 			oElem.Field(i).Set(nElem.Field(i))
-		} else if nElem.Field(i).Kind() == reflect.Ptr && nElem.Field(i).IsNil() && l.includeNilValues {
+		} else if nElem.Field(i).Kind() == reflect.Ptr && (!nElem.Field(i).IsNil() || l.includeNilValues) {
 			oElem.Field(i).Set(nElem.Field(i))
 		}
 	}

--- a/loader_test.go
+++ b/loader_test.go
@@ -719,7 +719,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Skip_Priority_Check() {
 	s.NoError(err)
 	s.Equal(17345, old.ID)
 	s.Equal("some text", old.Name)
-	s.Nil(old.Age)
+	s.Equal(25, *old.Age)
 	s.Equal(0, old.BankBalance)
 }
 

--- a/loader_test.go
+++ b/loader_test.go
@@ -686,7 +686,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Blank_Except_Id() {
 	s.NoError(err)
 	s.Equal(17345, old.ID)
 	s.Equal("", old.Name)
-	s.Nil(old.Age)
+	s.Equal(25, *old.Age)
 }
 
 func (s *loadDiffSuite) TestLoadDiff_DefaultBehaviour() {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

We are now using the same logic for when checking nil values. Now when we check too see if the the value has been updated, we check the type. This is because the `IsZero()` method returns false which is correct for pointers, however then the `includeZeroValues` flag is true which would then allow the if statement to be true.