### PR TITLE
fix(inserter): ignoring the pk from the inserter

### DIFF
--- a/inserter/sql.go
+++ b/inserter/sql.go
@@ -74,6 +74,11 @@ func (b *SQLBatch) genBatch(resources []any) {
 				tag = f.Name
 			}
 
+			tags := strings.Split(tag, patcher.TagOptSeparator)
+			if slices.Contains(tags, patcher.DBTagPrimaryKey) {
+				continue
+			}
+
 			b.args = append(b.args, b.getFieldValue(v.Field(i), f))
 
 			// if the field is not unique, skip it

--- a/inserter/sql_test.go
+++ b/inserter/sql_test.go
@@ -42,6 +42,37 @@ func (s *newBatchSuite) TestNewBatch_Success() {
 	s.Require().Len(b.Args(), 10)
 }
 
+func (s *newBatchSuite) TestNewBatch_Success_IgnorePK() {
+	type temp struct {
+		ID         int    `db:"id,pk"`
+		Name       string `db:"name"`
+		unexported string `db:"unexported"`
+	}
+
+	resources := []any{
+		&temp{ID: 1, Name: "test"},
+		&temp{ID: 2, Name: "test2"},
+		&temp{ID: 3, Name: "test3"},
+		&temp{ID: 4, Name: "test4"},
+		&temp{ID: 5, Name: "test5", unexported: "test"},
+	}
+
+	b := NewBatch(resources, WithTable("temp"), WithTagName("db"))
+
+	s.Require().Len(b.Fields(), 1)
+	s.Require().Len(b.Args(), 5)
+
+	s.Condition(func() bool {
+		for _, f := range b.Fields() {
+			if f == "id" {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
 func (s *newBatchSuite) TestNewBatch_Success_WithPointedFields() {
 	type temp struct {
 		ID         *int    `db:"id"`

--- a/sql.go
+++ b/sql.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	DefaultDbTagName = "db"
+	DBTagPrimaryKey  = "pk"
 )
 
 var (


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->
ignoring the pk from the inserter. At this point the ID of the struct will not exist as it is not yet in the database.