### PR TITLE
feat(comments): Updating comments for methods within the library

### DIFF
--- a/joiner.go
+++ b/joiner.go
@@ -1,5 +1,6 @@
 package patcher
 
+// Joiner is an interface that can be used to specify the JOIN clause to use when the SQL is being generated.
 type Joiner interface {
 	Join() (string, []any)
 }

--- a/loader.go
+++ b/loader.go
@@ -12,19 +12,22 @@ var (
 	ErrInvalidType = errors.New("invalid type: must pointer to struct")
 )
 
-// LoadDiff inserts the fields provided in the new struct pointer into the old struct pointer and injects the new
-// values into the old struct
+// LoadDiff inserts the fields from the new struct pointer into the old struct pointer, updating the old struct.
 //
-// Note that it only pushes non-zero value updates, meaning you cannot set any field to zero, the empty string, etc.
-// This is configurable by setting the includeZeroValues option to true or for nil values by setting includeNilValues.
+// Note that it only updates non-zero value fields, meaning you cannot set any field to zero, the empty string, etc.
+// This behavior is configurable by setting the includeZeroValues option to true or for nil values by setting includeNilValues.
 // Please see the LoaderOption's for more configuration options.
 //
-// This can be if you are inserting a patch into an existing object but require a new object to be returned with
-// all fields
+// This function is useful if you are inserting a patch into an existing object but require a new object to be returned with
+// all fields updated.
 func LoadDiff[T any](old *T, newT *T, opts ...PatchOpt) error {
 	return newPatchDefaults(opts...).loadDiff(old, newT)
 }
 
+// loadDiff inserts the fields provided in the new struct pointer into the old struct pointer and injects the new
+// values into the old struct. It only pushes non-zero value updates, meaning you cannot set any field to zero,
+// the empty string, etc. This is configurable by setting the includeZeroValues option to true or for nil values
+// by setting includeNilValues. It handles embedded structs and recursively calls loadDiff for nested structs.
 func (s *SQLPatch) loadDiff(old, newT any) error {
 	if !isPointerToStruct(old) || !isPointerToStruct(newT) {
 		return ErrInvalidType

--- a/patch.go
+++ b/patch.go
@@ -96,6 +96,7 @@ func newPatchDefaults(opts ...PatchOpt) *SQLPatch {
 	return p
 }
 
+// Fields returns the fields to update in the SQL statement
 func (s *SQLPatch) Fields() []string {
 	if len(s.fields) == 0 {
 		// Default behaviour is to return nil if there are no fields
@@ -104,6 +105,7 @@ func (s *SQLPatch) Fields() []string {
 	return s.fields
 }
 
+// Args returns the arguments to use in the SQL statement
 func (s *SQLPatch) Args() []any {
 	if len(s.args) == 0 {
 		// Default behaviour is to return nil if there are no args
@@ -112,6 +114,7 @@ func (s *SQLPatch) Args() []any {
 	return s.args
 }
 
+// validatePerformPatch validates the SQLPatch for the PerformPatch method
 func (s *SQLPatch) validatePerformPatch() error {
 	if s.db == nil {
 		return ErrNoDatabaseConnection
@@ -128,6 +131,7 @@ func (s *SQLPatch) validatePerformPatch() error {
 	return nil
 }
 
+// validateSQLGen validates the SQLPatch for the SQLGen method
 func (s *SQLPatch) validateSQLGen() error {
 	if s.table == "" {
 		return ErrNoTable
@@ -142,6 +146,7 @@ func (s *SQLPatch) validateSQLGen() error {
 	return nil
 }
 
+// shouldIncludeNil determines whether the field should be included in the patch
 func (s *SQLPatch) shouldIncludeNil(tag string) bool {
 	if s.includeNilValues {
 		return true
@@ -150,6 +155,7 @@ func (s *SQLPatch) shouldIncludeNil(tag string) bool {
 	return s.shouldOmitEmpty(tag)
 }
 
+// shouldIncludeZero determines whether zero values should be included in the patch
 func (s *SQLPatch) shouldIncludeZero(tag string) bool {
 	if s.includeZeroValues {
 		return true
@@ -158,6 +164,7 @@ func (s *SQLPatch) shouldIncludeZero(tag string) bool {
 	return s.shouldOmitEmpty(tag)
 }
 
+// shouldOmitEmpty determines whether the field should be omitted if it is empty
 func (s *SQLPatch) shouldOmitEmpty(tag string) bool {
 	if tag != "" {
 		tags := strings.Split(tag, TagOptSeparator)

--- a/sql.go
+++ b/sql.go
@@ -102,11 +102,9 @@ func (s *SQLPatch) patchGen(resource any) {
 
 		addField()
 
-		var val reflect.Value
+		val := fVal
 		if fVal.Kind() == reflect.Ptr {
 			val = fVal.Elem()
-		} else {
-			val = fVal
 		}
 
 		switch val.Kind() {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to improve the documentation and functionality of the `SQLPatch` class and related functions. The most important changes involve adding comments to functions and methods to clarify their purpose and usage, as well as minor code adjustments for better readability.

Documentation improvements:

* [`joiner.go`](diffhunk://#diff-cbc3e66aa73ab04bd45680048165e8f32035547825a87bbcad79800c359543caR3): Added a comment to the `Joiner` interface to specify its purpose in generating SQL JOIN clauses.
* [`loader.go`](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL15-R30): Enhanced the comment for the `LoadDiff` function to better explain its behavior and configuration options.
* [`patch.go`](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR99): Added comments to several methods in the `SQLPatch` class (`Fields`, `Args`, `validatePerformPatch`, `validateSQLGen`, `shouldIncludeNil`, `shouldIncludeZero`, `shouldOmitEmpty`) to describe their functionality. [[1]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR99) [[2]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR108) [[3]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR117) [[4]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR134) [[5]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR149) [[6]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR158) [[7]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aR167)
* [`sql.go`](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R22-R33): Added comments to various functions and methods related to the `SQLPatch` class to explain their purpose, including `NewSQLPatch`, `patchGen`, `GenerateSQL`, `PerformPatch`, and `PerformDiffPatch`. [[1]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R22-R33) [[2]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L99-L103) [[3]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R130-R140) [[4]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R179-R188) [[5]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R198-R201) [[6]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R215-R217)

Code readability improvements:

* [`sql.go`](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L99-L103): Simplified the assignment of `val` in the `patchGen` method by directly initializing it with `fVal`.