### PR TITLE
fix(gen): adding missing base types to the patch gen method

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -110,6 +110,12 @@ func (s *SQLPatch) patchGen(resource any) {
 		switch val.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			s.args = append(s.args, val.Int())
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			s.args = append(s.args, val.Uint())
+		case reflect.Float32, reflect.Float64:
+			s.args = append(s.args, val.Float())
+		case reflect.Complex64, reflect.Complex128:
+			s.args = append(s.args, val.Complex())
 		case reflect.String:
 			s.args = append(s.args, val.String())
 		case reflect.Bool:
@@ -118,8 +124,6 @@ func (s *SQLPatch) patchGen(resource any) {
 				boolArg = 1
 			}
 			s.args = append(s.args, boolArg)
-		case reflect.Float32, reflect.Float64:
-			s.args = append(s.args, val.Float())
 		default:
 			// This is intentionally a panic as this is a programming error and should be fixed by the developer
 			panic(fmt.Sprintf("unsupported type: %s", val.Kind()))

--- a/sql_test.go
+++ b/sql_test.go
@@ -33,6 +33,64 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success() {
 	s.Equal([]any{int64(1), "test"}, patch.args)
 }
 
+func (s *newSQLPatchSuite) TestPatchGen_AllTypes() {
+	type testObj struct {
+		IntVal        int
+		Int8Val       int8
+		Int16Val      int16
+		Int32Val      int32
+		Int64Val      int64
+		UintVal       uint
+		Uint8Val      uint8
+		Uint16Val     uint16
+		Uint32Val     uint32
+		Uint64Val     uint64
+		UintptrVal    uintptr
+		Float32Val    float32
+		Float64Val    float64
+		Complex64Val  complex64
+		Complex128Val complex128
+		StringVal     string
+		BoolVal       bool
+	}
+
+	obj := testObj{
+		IntVal:        1,
+		Int8Val:       2,
+		Int16Val:      3,
+		Int32Val:      4,
+		Int64Val:      5,
+		UintVal:       6,
+		Uint8Val:      7,
+		Uint16Val:     8,
+		Uint32Val:     9,
+		Uint64Val:     10,
+		UintptrVal:    11,
+		Float32Val:    12.34,
+		Float64Val:    56.78,
+		Complex64Val:  complex(1, 2),
+		Complex128Val: complex(3, 4),
+		StringVal:     "test",
+		BoolVal:       true,
+	}
+
+	patch := NewSQLPatch(obj)
+
+	expectedFields := []string{
+		"IntVal = ?", "Int8Val = ?", "Int16Val = ?", "Int32Val = ?", "Int64Val = ?",
+		"UintVal = ?", "Uint8Val = ?", "Uint16Val = ?", "Uint32Val = ?", "Uint64Val = ?", "UintptrVal = ?",
+		"Float32Val = ?", "Float64Val = ?", "Complex64Val = ?", "Complex128Val = ?", "StringVal = ?", "BoolVal = ?",
+	}
+	expectedArgs := []any{
+		int64(1), int64(2), int64(3), int64(4), int64(5),
+		uint64(6), uint64(7), uint64(8), uint64(9), uint64(10), uint64(11),
+		12.34000015258789, 56.78, complex(1, 2), complex(3, 4), "test", 1,
+	}
+
+	s.Equal(expectedFields, patch.fields)
+	s.Equal(expectedArgs, patch.args)
+}
+
 func (s *newSQLPatchSuite) TestNewSQLPatch_Success_MultipleTags() {
 	type testObj struct {
 		Id   *int    `db:"id_tag,pk"`


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `sql.go` and `sql_test.go` files to enhance the `SQLPatch` functionality and improve test coverage. The most important changes include adding support for more data types in the `patchGen` method and introducing a new test to verify this support.

Enhancements to `SQLPatch` functionality:

* [`sql.go`](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R113-R118): Added support for unsigned integers, floating-point numbers, and complex numbers in the `patchGen` method. [[1]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6R113-R118) [[2]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L121-L122)

Improvements to test coverage:

* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R36-R93): Added a new test `TestPatchGen_AllTypes` to verify that the `patchGen` method correctly handles all supported data types.