### PR TITLE
chore(tests): Updating tests to cover 80% total

### DIFF
--- a/patch_opts.go
+++ b/patch_opts.go
@@ -31,9 +31,6 @@ func WithTable(table string) PatchOpt {
 // WithWhere sets the where clause to use in the SQL statement
 func WithWhere(where Wherer) PatchOpt {
 	return func(s *SQLPatch) {
-		if s.whereSql == nil {
-			s.whereSql = new(strings.Builder)
-		}
 		fwSQL, fwArgs := where.Where()
 		if fwArgs == nil {
 			fwArgs = make([]any, 0)
@@ -53,9 +50,6 @@ func WithWhere(where Wherer) PatchOpt {
 // WithJoin sets the join clause to use in the SQL statement
 func WithJoin(join Joiner) PatchOpt {
 	return func(s *SQLPatch) {
-		if s.joinSql == nil {
-			s.joinSql = new(strings.Builder)
-		}
 		fjSQL, fjArgs := join.Join()
 		if fjArgs == nil {
 			fjArgs = make([]any, 0)

--- a/patch_test.go
+++ b/patch_test.go
@@ -1,0 +1,25 @@
+package patcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type newPatchSuite struct {
+	suite.Suite
+}
+
+func TestNewPatchSuite(t *testing.T) {
+	suite.Run(t, new(newPatchSuite))
+}
+
+func (s *newPatchSuite) TestNewPatch() {
+	mpo := NewMockPatchOpt(s.T())
+	mpo.On("Execute", mock.AnythingOfType("*patcher.SQLPatch"))
+
+	_ = newPatchDefaults(mpo.Execute)
+
+	mpo.AssertExpectations(s.T())
+}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `patcher` package, primarily focusing on enhancing the SQL patching functionality and adding comprehensive tests. The most important changes include removing redundant initializations in the `WithWhere` and `WithJoin` functions, adding new test suites and test cases, and improving the handling of different SQL patch scenarios.

Enhancements to SQL patching functionality:

* [`patch_opts.go`](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271L34-L36): Removed redundant initializations of `strings.Builder` in the `WithWhere` and `WithJoin` functions. [[1]](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271L34-L36) [[2]](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271L56-L58)

Addition of new test suites and test cases:

* [`patch_test.go`](diffhunk://#diff-6a3088703a7ff539221ee7bd72fa242d25593fe8a5ca7fd71cdf7af821158afcR1-R25): Added a new test suite `newPatchSuite` to test the `newPatchDefaults` function with mock expectations.
* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R39-R55): Added multiple test cases to the `newSQLPatchSuite`, including tests for fields and arguments getters, handling different tags, inclusion of nil and zero values, and ignored fields. [[1]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R39-R55) [[2]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R131-R147) [[3]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R464-R530)
* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R564-R588): Added a test case to the `generateSQLSuite` for generating SQL with no `Where` arguments and handling `WhereTypeOr` in the `TestGenerateSQL_Success_orWhere` function. [[1]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R564-R588) [[2]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L555-R686)
* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R1350-R1373): Added a test case to the `NewDiffSQLPatchSuite` for handling wrapped errors in the `TestNewDiffSQLPatch_Success_ignoreNoChanges_wrapped_normal` function.

These changes improve the robustness and test coverage of the SQL patching functionality, ensuring better handling of various scenarios and edge cases.