### PR TITLE
fix(docs): Update GO Reference badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Patcher
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/Jacobbrewer1/patcher.svg)](https://pkg.go.dev/github.com/Jacobbrewer1/patcher)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jacobbrewer1/patcher.svg)](https://pkg.go.dev/github.com/jacobbrewer1/patcher)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jacobbrewer1/patcher)](https://goreportcard.com/report/github.com/jacobbrewer1/patcher)
 
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a minor update to the `README.md` file. The change corrects the capitalization in the Go Reference badge URL. 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the Go Reference badge URL to use the correct capitalization for the username in the link.