### PR TITLE
fix(opts): Adding check to prevent calls on nil wherer or joiner

### DIFF
--- a/joiner.go
+++ b/joiner.go
@@ -8,6 +8,10 @@ type Joiner interface {
 }
 
 func appendJoin(join Joiner, builder *strings.Builder, args *[]any) {
+	if join == nil {
+		return
+	}
+
 	jSQL, jArgs := join.Join()
 	if jArgs == nil {
 		jArgs = make([]any, 0)

--- a/joiner.go
+++ b/joiner.go
@@ -11,7 +11,6 @@ func appendJoin(join Joiner, builder *strings.Builder, args *[]any) {
 	if join == nil {
 		return
 	}
-
 	jSQL, jArgs := join.Join()
 	if jArgs == nil {
 		jArgs = make([]any, 0)

--- a/wherer.go
+++ b/wherer.go
@@ -32,6 +32,9 @@ func (w WhereType) IsValid() bool {
 }
 
 func appendWhere(where Wherer, builder *strings.Builder, args *[]any) {
+	if where == nil {
+		return
+	}
 	wSQL, fwArgs := where.Where()
 	if fwArgs == nil {
 		fwArgs = make([]any, 0)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the `joiner.go` and `wherer.go` files to improve the robustness of the `appendJoin` and `appendWhere` functions by adding nil checks.

Improvements to function robustness:

* [`joiner.go`](diffhunk://#diff-cbc3e66aa73ab04bd45680048165e8f32035547825a87bbcad79800c359543caR11-R14): Added a nil check for the `Joiner` interface in the `appendJoin` function to prevent potential nil pointer dereferences.
* [`wherer.go`](diffhunk://#diff-4b2cc41829c8fd154e23442cfdb360d0def1a767d947e4995b601d9181ae0256R35-R37): Added a nil check for the `Wherer` interface in the `appendWhere` function to prevent potential nil pointer dereferences.