### PR TITLE
chore(opts): Removing case-insensative ignore field, cases now need to match

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -114,7 +114,7 @@ func (s *SQLPatch) checkSkipTag(field reflect.StructField) bool {
 }
 
 func (s *SQLPatch) ignoredFieldsCheck(field reflect.StructField) bool {
-	return s.checkIgnoredFields(strings.ToLower(field.Name)) || s.checkIgnoreFunc(field)
+	return s.checkIgnoredFields(field.Name) || s.checkIgnoreFunc(field)
 }
 
 func (s *SQLPatch) checkIgnoreFunc(field reflect.StructField) bool {
@@ -122,5 +122,5 @@ func (s *SQLPatch) checkIgnoreFunc(field reflect.StructField) bool {
 }
 
 func (s *SQLPatch) checkIgnoredFields(field string) bool {
-	return len(s.ignoreFields) > 0 && slices.Contains(s.ignoreFields, strings.ToLower(field))
+	return len(s.ignoreFields) > 0 && slices.Contains(s.ignoreFields, field)
 }

--- a/loader_test.go
+++ b/loader_test.go
@@ -647,7 +647,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Include_Nil_false() {
 
 func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFields() {
 	l := s.patch
-	l.ignoreFields = []string{"name"}
+	l.ignoreFields = []string{"Name"}
 
 	type testStruct struct {
 		Name string
@@ -728,7 +728,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFieldsFuncAndIgnoreFields() {
 func (s *loadDiffSuite) TestLoadDiff_Success_Blank_Except_Id() {
 	l := s.patch
 	l.includeZeroValues = true
-	l.ignoreFields = []string{"id"}
+	l.ignoreFields = []string{"ID"}
 
 	type testStruct struct {
 		ID   int
@@ -758,7 +758,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Blank_Except_Id() {
 func (s *loadDiffSuite) TestLoadDiff_Success_Skip_Priority_Check() {
 	l := s.patch
 	l.includeZeroValues = true
-	l.ignoreFields = []string{"id"}
+	l.ignoreFields = []string{"ID"}
 
 	type testStruct struct {
 		ID          int

--- a/patch_opts.go
+++ b/patch_opts.go
@@ -2,7 +2,6 @@ package patcher
 
 import (
 	"database/sql"
-	"strings"
 )
 
 const (
@@ -75,10 +74,6 @@ func WithIncludeNilValues() PatchOpt {
 // case-sensitive.
 func WithIgnoredFields(fields ...string) PatchOpt {
 	return func(s *SQLPatch) {
-		for i := range fields {
-			fields[i] = strings.ToLower(fields[i])
-		}
-
 		s.ignoreFields = fields
 	}
 }

--- a/sql.go
+++ b/sql.go
@@ -261,7 +261,7 @@ func NewDiffSQLPatch[T any](old, newT *T, opts ...PatchOpt) (*SQLPatch, error) {
 			if patch.ignoreFields == nil {
 				patch.ignoreFields = make([]string, 0)
 			}
-			patch.ignoreFields = append(patch.ignoreFields, strings.ToLower(oldElem.Type().Field(i).Name))
+			patch.ignoreFields = append(patch.ignoreFields, oldElem.Type().Field(i).Name)
 			continue
 		}
 	}

--- a/sql_test.go
+++ b/sql_test.go
@@ -518,7 +518,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IgnoredFields() {
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues(), WithIncludeZeroValues(), WithIgnoredFields("id", "description"))
+	patch := NewSQLPatch(obj, WithIncludeNilValues(), WithIncludeZeroValues(), WithIgnoredFields("Id", "Description"))
 
 	s.Equal([]string{"name = ?"}, patch.fields)
 	s.Equal([]any{""}, patch.args)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `SQLPatch` class and related test cases to improve the handling of ignored fields. The main focus is on ensuring case sensitivity for ignored fields and removing unnecessary string manipulations.

### Improvements to handling of ignored fields:

* [`loader.go`](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL117-R125): Modified the `ignoredFieldsCheck` and `checkIgnoredFields` methods to handle field names without converting them to lowercase.
* [`loader_test.go`](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L650-R650): Updated test cases to use case-sensitive field names in the `ignoreFields` list. [[1]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L650-R650) [[2]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L731-R731) [[3]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L761-R761)
* [`patch_opts.go`](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271L78-L81): Removed the conversion of field names to lowercase in the `WithIgnoredFields` function.
* [`sql.go`](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L264-R264): Adjusted the `NewDiffSQLPatch` function to append field names without converting them to lowercase.
* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L521-R521): Updated test cases to use case-sensitive field names in the `WithIgnoredFields` function.

### Codebase simplification:

* [`patch_opts.go`](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271L5): Removed the unused import of the `strings` package.