### PR TITLE
feat(opts): Adding with and join string methods

### DIFF
--- a/joiner.go
+++ b/joiner.go
@@ -19,3 +19,12 @@ func appendJoin(join Joiner, builder *strings.Builder, args *[]any) {
 	builder.WriteString("\n")
 	*args = append(*args, jArgs...)
 }
+
+type joinStringOption struct {
+	join string
+	args []any
+}
+
+func (j *joinStringOption) Join() (string, []any) {
+	return j.join, j.args
+}

--- a/patch_opts.go
+++ b/patch_opts.go
@@ -34,10 +34,38 @@ func WithWhere(where Wherer) PatchOpt {
 	}
 }
 
+// WithWhereStr takes a string and args to set the where clause to use in the SQL statement. This is useful when you
+// want to use a simple where clause.
+//
+// Note. The where string should not contain the "WHERE" keyword. We recommend using the WhereTyper interface if you
+// want to specify the WHERE type or do a more complex WHERE clause.
+func WithWhereStr(where string, args ...any) PatchOpt {
+	return func(s *SQLPatch) {
+		appendWhere(&whereStringOption{
+			where: where,
+			args:  args,
+		}, s.whereSql, &s.whereArgs)
+	}
+}
+
 // WithJoin sets the join clause to use in the SQL statement
 func WithJoin(join Joiner) PatchOpt {
 	return func(s *SQLPatch) {
 		appendJoin(join, s.joinSql, &s.joinArgs)
+	}
+}
+
+// WithJoinStr takes a string and args to set the join clause to use in the SQL statement. This is useful when you
+// want to use a simple join clause.
+//
+// Note. The join string should not contain the "JOIN" keyword. We recommend using the Joiner interface if you
+// want to specify the JOIN type or do a more complex JOIN clause.
+func WithJoinStr(join string, args ...any) PatchOpt {
+	return func(s *SQLPatch) {
+		appendJoin(&joinStringOption{
+			join: join,
+			args: args,
+		}, s.joinSql, &s.joinArgs)
 	}
 }
 

--- a/sql.go
+++ b/sql.go
@@ -144,7 +144,7 @@ func GenerateSQL(resource any, opts ...PatchOpt) (string, []any, error) {
 // and returns the final SQL string along with the arguments.
 func (s *SQLPatch) GenerateSQL() (string, []any, error) {
 	if err := s.validateSQLGen(); err != nil {
-		return "", nil, fmt.Errorf("validate perform patch: %w", err)
+		return "", nil, fmt.Errorf("validate SQL generation: %w", err)
 	}
 
 	sqlBuilder := new(strings.Builder)

--- a/sql_test.go
+++ b/sql_test.go
@@ -652,13 +652,19 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_JoinString() {
 		Name: ptr("test"),
 	}
 
+	mw := NewMockWherer(s.T())
+	mw.On("Where").Return("age = ?", []any{18})
+
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
 		WithJoinStr("JOIN table2 ON table1.id = table2.id"),
+		WithWhere(mw),
 	)
 	s.NoError(err)
-	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nJOIN table2 ON table1.id = table2.id\n", sqlStr)
-	s.Equal([]any{int64(1), "test"}, args)
+	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
+	s.Equal([]any{int64(1), "test", 18}, args)
+
+	mw.AssertExpectations(s.T())
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_Success_NoWhereArgs() {

--- a/wherer.go
+++ b/wherer.go
@@ -49,3 +49,12 @@ func appendWhere(where Wherer, builder *strings.Builder, args *[]any) {
 	builder.WriteString("\n")
 	*args = append(*args, fwArgs...)
 }
+
+type whereStringOption struct {
+	where string
+	args  []any
+}
+
+func (w *whereStringOption) Where() (string, []any) {
+	return w.where, w.args
+}


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces new functionalities to simplify the creation of SQL statements by adding string-based options for `WHERE` and `JOIN` clauses. Additionally, it includes corresponding tests to ensure the new functionalities work as expected.

### New functionalities:

* [`joiner.go`](diffhunk://#diff-cbc3e66aa73ab04bd45680048165e8f32035547825a87bbcad79800c359543caR22-R30): Added `joinStringOption` type and `Join` method to support string-based `JOIN` clauses.
* [`patch_opts.go`](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271R37-R71): Added `WithWhereStr` and `WithJoinStr` functions to set `WHERE` and `JOIN` clauses using strings and arguments.
* [`wherer.go`](diffhunk://#diff-4b2cc41829c8fd154e23442cfdb360d0def1a767d947e4995b601d9181ae0256R52-R60): Added `whereStringOption` type and `Where` method to support string-based `WHERE` clauses.

### Tests:

* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R59-R98): Added `TestNewSQLPatch_WhereString` and `TestNewSQLPatch_JoinString` to test `WithWhereStr` and `WithJoinStr` functionalities.
* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R624-R663): Added `TestGenerateSQL_Success_WhereString` and `TestGenerateSQL_Success_JoinString` to validate the generation of SQL statements using the new string-based options.