### PR TITLE
feat(opts): Adding a generic `WithFilter` option that takes a joiner or wherer

### DIFF
--- a/patch_opts.go
+++ b/patch_opts.go
@@ -30,12 +30,12 @@ func WithTable(table string) PatchOpt {
 // WithFilter takes in either a Wherer or a Joiner to set the filter to use in the SQL statement
 func WithFilter(filter any) PatchOpt {
 	return func(s *SQLPatch) {
-		if where, ok := filter.(Wherer); ok {
-			WithWhere(where)(s)
-		}
-
 		if join, ok := filter.(Joiner); ok {
 			WithJoin(join)(s)
+		}
+
+		if where, ok := filter.(Wherer); ok {
+			WithWhere(where)(s)
 		}
 	}
 }

--- a/patch_opts.go
+++ b/patch_opts.go
@@ -27,6 +27,19 @@ func WithTable(table string) PatchOpt {
 	}
 }
 
+// WithFilter takes in either a Wherer or a Joiner to set the filter to use in the SQL statement
+func WithFilter(filter any) PatchOpt {
+	return func(s *SQLPatch) {
+		if where, ok := filter.(Wherer); ok {
+			WithWhere(where)(s)
+		}
+
+		if join, ok := filter.(Joiner); ok {
+			WithJoin(join)(s)
+		}
+	}
+}
+
 // WithWhere sets the where clause to use in the SQL statement
 func WithWhere(where Wherer) PatchOpt {
 	return func(s *SQLPatch) {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a new function to handle SQL filters and adds a corresponding test case to ensure its functionality. The main changes are:

Enhancements to SQL filter handling:

* [`patch_opts.go`](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271R30-R42): Added a new function `WithFilter` that accepts either a `Wherer` or a `Joiner` to set the filter in the SQL statement.

Testing improvements:

* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5R624-R653): Introduced a new struct `testFilter` implementing both `Where` and `Join` methods, and added a test case `TestGenerateSQL_Success_WhereAndJoin` to verify the `WithFilter` function.