### PR TITLE
feat(multifilter): Adding Joiner interface to the MultiFilter

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -63,7 +63,7 @@ jobs:
         
       - name: Check code coverage
         run: |
-          go test -coverprofile=coverage.out $(go list ./... | grep -v /examples)
+          go test -coverprofile=coverage.out -coverpkg=$(go list ./... | grep -v /examples | grep -v 'mock_') $(go list ./... | grep -v /examples)
           coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
           if (( $(echo "$coverage < 80" | bc -l) )); then
             echo "Code coverage is below 80%: $coverage%"

--- a/mock_MultiFilter.go
+++ b/mock_MultiFilter.go
@@ -10,8 +10,38 @@ type MockMultiFilter struct {
 }
 
 // Add provides a mock function with given fields: where
-func (_m *MockMultiFilter) Add(where Wherer) {
+func (_m *MockMultiFilter) Add(where interface{}) {
 	_m.Called(where)
+}
+
+// Join provides a mock function with no fields
+func (_m *MockMultiFilter) Join() (string, []interface{}) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Join")
+	}
+
+	var r0 string
+	var r1 []interface{}
+	if rf, ok := ret.Get(0).(func() (string, []interface{})); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func() []interface{}); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]interface{})
+		}
+	}
+
+	return r0, r1
 }
 
 // Where provides a mock function with no fields

--- a/multifilter_test.go
+++ b/multifilter_test.go
@@ -61,3 +61,54 @@ func (s *multiFilterSuite) TestNewMultiFilter_Add_WhereTyper() {
 	s.Equal("AND where\nOR whereTwo\n", sql)
 	s.Equal([]any{"arg1", "arg2", "arg3", "arg4"}, args)
 }
+
+func (s *multiFilterSuite) TestNewMultiFilter_Add_Joiner() {
+	mf := NewMultiFilter()
+	s.NotNil(mf)
+
+	mj := NewMockJoiner(s.T())
+	mj.On("Join").Return("join", []any{"arg1", "arg2"})
+	mf.Add(mj)
+
+	sql, args := mf.Join()
+	s.Equal("join\n", sql)
+	s.Equal([]any{"arg1", "arg2"}, args)
+}
+
+func (s *multiFilterSuite) TestNewMultiFilter_Add_MultiJoiner() {
+	mf := NewMultiFilter()
+	s.NotNil(mf)
+
+	mj := NewMockJoiner(s.T())
+	mj.On("Join").Return("join", []any{"arg1", "arg2"})
+	mf.Add(mj)
+
+	mjTwo := NewMockJoiner(s.T())
+	mjTwo.On("Join").Return("joinTwo", []any{"arg3", "arg4"})
+	mf.Add(mjTwo)
+
+	sql, args := mf.Join()
+	s.Equal("join\njoinTwo\n", sql)
+	s.Equal([]any{"arg1", "arg2", "arg3", "arg4"}, args)
+}
+
+func (s *multiFilterSuite) TestNewMultiFilter_Add_JoinerAndWherer() {
+	mf := NewMultiFilter()
+	s.NotNil(mf)
+
+	mj := NewMockJoiner(s.T())
+	mj.On("Join").Return("join", []any{"arg1", "arg2"})
+	mf.Add(mj)
+
+	mw := NewMockWherer(s.T())
+	mw.On("Where").Return("where", []any{"arg3", "arg4"})
+	mf.Add(mw)
+
+	sql, args := mf.Join()
+	s.Equal("join\n", sql)
+	s.Equal([]any{"arg1", "arg2"}, args)
+
+	sql, args = mf.Where()
+	s.Equal("AND where\n", sql)
+	s.Equal([]any{"arg3", "arg4"}, args)
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -56,6 +56,47 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_MultiFilter() {
 	s.Equal([]any{int64(1), "test"}, patch.args)
 }
 
+func (s *newSQLPatchSuite) TestNewSQLPatch_Success_MultiFilter_Joiner() {
+	type testObj struct {
+		Id   *int    `db:"id_tag"`
+		Name *string `db:"name_tag"`
+	}
+
+	obj := testObj{
+		Id:   ptr(1),
+		Name: ptr("test"),
+	}
+
+	mf := NewMockMultiFilter(s.T())
+	mf.On("Join").Return("JOIN table2 ON table1.id = table2.id", nil)
+
+	patch := NewSQLPatch(obj, WithJoin(mf))
+
+	s.Equal([]string{"id_tag = ?", "name_tag = ?"}, patch.fields)
+	s.Equal([]any{int64(1), "test"}, patch.args)
+}
+
+func (s *newSQLPatchSuite) TestNewSQLPatch_Success_MultiFilter_JoinerAndWhere() {
+	type testObj struct {
+		Id   *int    `db:"id_tag"`
+		Name *string `db:"name_tag"`
+	}
+
+	obj := testObj{
+		Id:   ptr(1),
+		Name: ptr("test"),
+	}
+
+	mf := NewMockMultiFilter(s.T())
+	mf.On("Join").Return("JOIN table2 ON table1.id = table2.id", nil)
+	mf.On("Where").Return("where", []any{"arg1", "arg2"})
+
+	patch := NewSQLPatch(obj, WithJoin(mf), WithWhere(mf))
+
+	s.Equal([]string{"id_tag = ?", "name_tag = ?"}, patch.fields)
+	s.Equal([]any{int64(1), "test"}, patch.args)
+}
+
 func (s *newSQLPatchSuite) TestNewSQLPatch_WhereString() {
 	type testObj struct {
 		Id   *int    `db:"id_tag"`


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes significant updates to the `MultiFilter` interface and its implementation in the `multifilter.go` file, along with corresponding tests in `multifilter_test.go`. The changes enhance the functionality of the `MultiFilter` by incorporating join operations and updating the `Add` method to handle multiple types of filters.

Enhancements to `MultiFilter`:

* [`multifilter.go`](diffhunk://#diff-3262e86d1549095cd309f6f3b377d0ce864bf5c13ca0ec0bc47a0f213a4179d2R6-R42): Added `Joiner` interface to `MultiFilter` and updated the `Add` method to accept any type of filter, handling both `Joiner` and `Wherer` types.
* [`multifilter.go`](diffhunk://#diff-3262e86d1549095cd309f6f3b377d0ce864bf5c13ca0ec0bc47a0f213a4179d2R6-R42): Implemented `Join` method to return join SQL and arguments, and updated `NewMultiFilter` to initialize join-related fields.

Updates to tests:

* [`multifilter_test.go`](diffhunk://#diff-073f4daf31cdda4887fb8d3affb05d53ed2462c39e763c3f429014e419335736R64-R114): Added tests for the new `Join` method and for adding `Joiner` and `Wherer` filters to `MultiFilter`. These tests ensure that the `MultiFilter` correctly handles join operations and maintains the expected SQL and arguments.