### PR TITLE
feat(cicd): Adding additional golangci linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,137 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,12 @@ linters:
     - iface
     - thelper
     - tparallel
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - revive
+      text: "^(enforce-slice-style|enforce-map-style)"
 linters-settings:
   revive:
     # Default: false

--- a/examples/basic_with_opts/main.go
+++ b/examples/basic_with_opts/main.go
@@ -50,7 +50,7 @@ func main() {
 		patcher.WithIncludeZeroValues(),
 		patcher.WithIncludeNilValues(),
 		patcher.WithIgnoredFields("ignoredbylist"),
-		patcher.WithIgnoredFieldsFunc(func(field reflect.StructField) bool {
+		patcher.WithIgnoredFieldsFunc(func(field *reflect.StructField) bool {
 			return strings.ToLower(field.Name) == "ignoredbyfunc"
 		}),
 	)

--- a/examples/loader_with_opts/main.go
+++ b/examples/loader_with_opts/main.go
@@ -53,7 +53,7 @@ func main() {
 		patcher.WithIncludeZeroValues(),
 		patcher.WithIncludeNilValues(),
 		patcher.WithIgnoredFields("ignoredField", "IgNoReDfIeLdTwO"),
-		patcher.WithIgnoredFieldsFunc(func(field reflect.StructField) bool {
+		patcher.WithIgnoredFieldsFunc(func(field *reflect.StructField) bool {
 			return strings.ToLower(field.Name) == "ignoredfieldbyfunc"
 		}),
 	); err != nil {

--- a/inserter/sql_test.go
+++ b/inserter/sql_test.go
@@ -484,7 +484,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IgnoredFieldsFunc() {
 	}
 
 	mif := patcher.NewMockIgnoreFieldsFunc(s.T())
-	mif.On("Execute", mock.Anything).Return(func(f reflect.StructField) bool {
+	mif.On("Execute", mock.AnythingOfType("*reflect.StructField")).Return(func(f *reflect.StructField) bool {
 		return f.Name == "ID"
 	})
 

--- a/inserter/sql_test.go
+++ b/inserter/sql_test.go
@@ -416,7 +416,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields() {
 
 	s.Equal("INSERT INTO temp (id, name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 
-	expectedArgs := []any{1, "test", interface{}(nil), "test2", 3, "test3", 4, "test4", 5, "test5"}
+	expectedArgs := []any{1, "test", any(nil), "test2", 3, "test3", 4, "test4", 5, "test5"}
 	s.Require().Equal(expectedArgs, args)
 }
 
@@ -440,7 +440,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields_noDbTag() {
 
 	s.Equal("INSERT INTO temp (ID, Name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 
-	expectedArgs := []any{1, "test", interface{}(nil), "test2", 3, "test3", 4, "test4", 5, "test5"}
+	expectedArgs := []any{1, "test", any(nil), "test2", 3, "test3", 4, "test4", 5, "test5"}
 	s.Require().Equal(expectedArgs, args)
 }
 

--- a/joiner.go
+++ b/joiner.go
@@ -25,6 +25,6 @@ type joinStringOption struct {
 	args []any
 }
 
-func (j *joinStringOption) Join() (string, []any) {
+func (j *joinStringOption) Join() (sqlStr string, args []any) {
 	return j.join, j.args
 }

--- a/loader_test.go
+++ b/loader_test.go
@@ -672,8 +672,8 @@ func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFields() {
 
 func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFieldsFunc() {
 	l := s.patch
-	l.ignoreFieldsFunc = func(field reflect.StructField) bool {
-		return strings.ToLower(field.Name) == "name"
+	l.ignoreFieldsFunc = func(field *reflect.StructField) bool {
+		return strings.EqualFold(field.Name, "name")
 	}
 
 	type testStruct struct {
@@ -700,8 +700,8 @@ func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFieldsFunc() {
 func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFieldsFuncAndIgnoreFields() {
 	l := s.patch
 	l.ignoreFields = []string{"name"}
-	l.ignoreFieldsFunc = func(field reflect.StructField) bool {
-		return strings.ToLower(field.Name) == "name"
+	l.ignoreFieldsFunc = func(field *reflect.StructField) bool {
+		return strings.EqualFold(field.Name, "name")
 	}
 
 	type testStruct struct {

--- a/mock_IgnoreFieldsFunc.go
+++ b/mock_IgnoreFieldsFunc.go
@@ -14,7 +14,7 @@ type MockIgnoreFieldsFunc struct {
 }
 
 // Execute provides a mock function with given fields: field
-func (_m *MockIgnoreFieldsFunc) Execute(field reflect.StructField) bool {
+func (_m *MockIgnoreFieldsFunc) Execute(field *reflect.StructField) bool {
 	ret := _m.Called(field)
 
 	if len(ret) == 0 {
@@ -22,7 +22,7 @@ func (_m *MockIgnoreFieldsFunc) Execute(field reflect.StructField) bool {
 	}
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(reflect.StructField) bool); ok {
+	if rf, ok := ret.Get(0).(func(*reflect.StructField) bool); ok {
 		r0 = rf(field)
 	} else {
 		r0 = ret.Get(0).(bool)

--- a/multifilter.go
+++ b/multifilter.go
@@ -15,11 +15,11 @@ type multiFilter struct {
 	whereArgs []any
 }
 
-func (m *multiFilter) Join() (string, []any) {
+func (m *multiFilter) Join() (sqlStr string, args []any) {
 	return m.joinSql.String(), m.joinArgs
 }
 
-func (m *multiFilter) Where() (string, []any) {
+func (m *multiFilter) Where() (sqlStr string, args []any) {
 	return m.whereSql.String(), m.whereArgs
 }
 

--- a/patch.go
+++ b/patch.go
@@ -25,7 +25,7 @@ var (
 	ErrNoWhere = errors.New("no where clause set")
 )
 
-type IgnoreFieldsFunc func(field reflect.StructField) bool
+type IgnoreFieldsFunc func(field *reflect.StructField) bool
 
 type SQLPatch struct {
 	// fields is the fields to update in the SQL statement
@@ -116,34 +116,36 @@ func (s *SQLPatch) Args() []any {
 
 // validatePerformPatch validates the SQLPatch for the PerformPatch method
 func (s *SQLPatch) validatePerformPatch() error {
-	if s.db == nil {
+	switch {
+	case s.db == nil:
 		return ErrNoDatabaseConnection
-	} else if s.table == "" {
+	case s.table == "":
 		return ErrNoTable
-	} else if len(s.fields) == 0 {
+	case len(s.fields) == 0:
 		return ErrNoFields
-	} else if len(s.args) == 0 {
+	case len(s.args) == 0:
 		return ErrNoArgs
-	} else if s.whereSql.String() == "" {
+	case s.whereSql.String() == "":
 		return ErrNoWhere
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 // validateSQLGen validates the SQLPatch for the SQLGen method
 func (s *SQLPatch) validateSQLGen() error {
-	if s.table == "" {
+	switch {
+	case s.table == "":
 		return ErrNoTable
-	} else if len(s.fields) == 0 {
+	case len(s.fields) == 0:
 		return ErrNoFields
-	} else if len(s.args) == 0 {
+	case len(s.args) == 0:
 		return ErrNoArgs
-	} else if s.whereSql.String() == "" {
+	case s.whereSql.String() == "":
 		return ErrNoWhere
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 // shouldIncludeNil determines whether the field should be included in the patch

--- a/sql_test.go
+++ b/sql_test.go
@@ -367,8 +367,8 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_fail_noFields() {
 	// This will return a patch object with no fields
 	patch := NewSQLPatch(obj)
 
-	s.Equal(make([]string, 0), patch.fields)
-	s.Equal(make([]any, 0), patch.args)
+	s.Equal([]string{}, patch.fields)
+	s.Equal([]any{}, patch.args)
 }
 
 func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeZeroValue() {
@@ -982,10 +982,10 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_multipleJoin() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	mj := NewMockJoiner(s.T())
-	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", make([]any, 0))
+	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", []any{})
 
 	mj2 := NewMockJoiner(s.T())
-	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", make([]any, 0))
+	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", []any{})
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
@@ -1015,7 +1015,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoinAndWhere() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	mj := NewMockJoiner(s.T())
-	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", make([]any, 0))
+	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", []any{})
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
@@ -1044,10 +1044,10 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoinAndWhereAndJoin() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	mj := NewMockJoiner(s.T())
-	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", make([]any, 0))
+	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", []any{})
 
 	mj2 := NewMockJoiner(s.T())
-	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", make([]any, 0))
+	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", []any{})
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),

--- a/sql_test.go
+++ b/sql_test.go
@@ -367,8 +367,8 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_fail_noFields() {
 	// This will return a patch object with no fields
 	patch := NewSQLPatch(obj)
 
-	s.Equal([]string{}, patch.fields)
-	s.Equal([]any{}, patch.args)
+	s.Equal(make([]string, 0), patch.fields)
+	s.Equal(make([]any, 0), patch.args)
 }
 
 func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeZeroValue() {
@@ -619,7 +619,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IgnoredFieldsFunc() {
 	}
 
 	ignoreFunc := NewMockIgnoreFieldsFunc(s.T())
-	ignoreFunc.On("Execute", mock.AnythingOfType("reflect.StructField")).Return(func(field reflect.StructField) bool {
+	ignoreFunc.On("Execute", mock.AnythingOfType("reflect.StructField")).Return(func(field *reflect.StructField) bool {
 		return field.Name == "Id" || field.Name == "Description"
 	})
 
@@ -664,11 +664,11 @@ func (s *generateSQLSuite) TestGenerateSQL_Success() {
 
 type testFilter struct{}
 
-func (f *testFilter) Where() (string, []any) {
+func (f *testFilter) Where() (sqlStr string, args []any) {
 	return "age = ?", []any{18}
 }
 
-func (f *testFilter) Join() (string, []any) {
+func (f *testFilter) Join() (sqlStr string, args []any) {
 	return "JOIN table2 ON table1.id = table2.id", nil
 }
 
@@ -982,10 +982,10 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_multipleJoin() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	mj := NewMockJoiner(s.T())
-	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", []any{})
+	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", make([]any, 0))
 
 	mj2 := NewMockJoiner(s.T())
-	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", []any{})
+	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", make([]any, 0))
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
@@ -1015,7 +1015,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoinAndWhere() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	mj := NewMockJoiner(s.T())
-	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", []any{})
+	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", make([]any, 0))
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
@@ -1044,10 +1044,10 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoinAndWhereAndJoin() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	mj := NewMockJoiner(s.T())
-	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", []any{})
+	mj.On("Join").Return("JOIN table2 ON table1.id = table2.id", make([]any, 0))
 
 	mj2 := NewMockJoiner(s.T())
-	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", []any{})
+	mj2.On("Join").Return("JOIN table3 ON table1.id = table3.id", make([]any, 0))
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),

--- a/sql_test.go
+++ b/sql_test.go
@@ -619,7 +619,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IgnoredFieldsFunc() {
 	}
 
 	ignoreFunc := NewMockIgnoreFieldsFunc(s.T())
-	ignoreFunc.On("Execute", mock.AnythingOfType("reflect.StructField")).Return(func(field *reflect.StructField) bool {
+	ignoreFunc.On("Execute", mock.AnythingOfType("*reflect.StructField")).Return(func(field *reflect.StructField) bool {
 		return field.Name == "Id" || field.Name == "Description"
 	})
 

--- a/wherer.go
+++ b/wherer.go
@@ -55,6 +55,6 @@ type whereStringOption struct {
 	args  []any
 }
 
-func (w *whereStringOption) Where() (string, []any) {
+func (w *whereStringOption) Where() (sqlStr string, args []any) {
 	return w.where, w.args
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to enhance the codebase by improving type safety, updating function signatures, and refining linter configurations. The most important changes are grouped by theme below.

### Function Signature Updates:

* Updated various function signatures to accept pointers to `reflect.StructField` instead of values to improve type safety and consistency. (`examples/basic_with_opts/main.go`, `examples/loader_with_opts/main.go`, `inserter/sql.go`, `loader.go`, `patch.go`, `mock_IgnoreFieldsFunc.go`) [[1]](diffhunk://#diff-1ca44a8bf1e50aaf6ed31c1c872526e35fbcd27adf61fd4a113a05d83d50bde9L53-R53) [[2]](diffhunk://#diff-dbd94054314c72afb50f3c35a2a1f7830078ce7078ac4871371c62c704c0abc8L56-R56) [[3]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL65-R65) [[4]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL82-R82) [[5]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL96-R96) [[6]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL107-R107) [[7]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL148-R148) [[8]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL162-R162) [[9]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL172-R172) [[10]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL187-R196) [[11]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L419-R419) [[12]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L443-R443) [[13]](diffhunk://#diff-cbc3e66aa73ab04bd45680048165e8f32035547825a87bbcad79800c359543caL28-R28) [[14]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL23-R23) [[15]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eR77-R84) [[16]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL97-R99) [[17]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL106-R108) [[18]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL116-R122) [[19]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L675-R676) [[20]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L703-R704) [[21]](diffhunk://#diff-fec5a3fba43b25f18a572bb94a1788d118609301ba91f3e45f4f8ffd43d83e4bL17-R25) [[22]](diffhunk://#diff-3262e86d1549095cd309f6f3b377d0ce864bf5c13ca0ec0bc47a0f213a4179d2L18-R22) [[23]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aL28-R28) [[24]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aL119-R149) [[25]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L71-R76) [[26]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L137-R146)

### Linter Configuration:

* Added and configured multiple linters in the `.golangci.yaml` file to enforce code quality and consistency, including `revive`, `sloglint`, `godox`, `gosec`, `musttag`, `nilnil`, `goconst`, `gocritic`, `gofmt`, `iface`, `thelper`, and `tparallel`. (`.golangci.yaml`)

### Code Simplification:

* Simplified the `validatePerformPatch` and `validateSQLGen` methods by using `switch` statements instead of multiple `if-else` checks. (`patch.go`)

### Test Updates:

* Updated tests to reflect changes in function signatures and to use `any(nil)` instead of `interface{}(nil)` for consistency. (`inserter/sql_test.go`, `loader_test.go`) [[1]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L419-R419) [[2]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L443-R443) [[3]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L675-R676) [[4]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L703-R704)

### Miscellaneous:

* Updated the `GenerateSQL` function signatures to use named return values for better readability. (`inserter/sql.go`, `sql.go`) [[1]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL107-R107) [[2]](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L137-R146)