### PR TITLE
chore(opts): taking a parameter on the include zero and nil opts

### DIFF
--- a/examples/basic_with_opts/main.go
+++ b/examples/basic_with_opts/main.go
@@ -47,8 +47,8 @@ func main() {
 		person,
 		patcher.WithTable("people"),
 		patcher.WithWhere(condition),
-		patcher.WithIncludeZeroValues(),
-		patcher.WithIncludeNilValues(),
+		patcher.WithIncludeZeroValues(true),
+		patcher.WithIncludeNilValues(true),
 		patcher.WithIgnoredFields("ignoredbylist"),
 		patcher.WithIgnoredFieldsFunc(func(field reflect.StructField) bool {
 			return strings.ToLower(field.Name) == "ignoredbyfunc"

--- a/examples/loader_with_opts/main.go
+++ b/examples/loader_with_opts/main.go
@@ -50,8 +50,8 @@ func main() {
 
 	// The patcher.LoadDiff function will apply the changes from n to s.
 	if err := patcher.LoadDiff(&s, &n,
-		patcher.WithIncludeZeroValues(),
-		patcher.WithIncludeNilValues(),
+		patcher.WithIncludeZeroValues(true),
+		patcher.WithIncludeNilValues(true),
 		patcher.WithIgnoredFields("ignoredField", "IgNoReDfIeLdTwO"),
 		patcher.WithIgnoredFieldsFunc(func(field reflect.StructField) bool {
 			return strings.ToLower(field.Name) == "ignoredfieldbyfunc"

--- a/patch_opts.go
+++ b/patch_opts.go
@@ -92,18 +92,18 @@ func WithDB(db *sql.DB) PatchOpt {
 // WithIncludeZeroValues sets whether zero values should be included in the patch.
 //
 // This is useful when you want to set a field to zero.
-func WithIncludeZeroValues() PatchOpt {
+func WithIncludeZeroValues(includeZeroValues bool) PatchOpt {
 	return func(s *SQLPatch) {
-		s.includeZeroValues = true
+		s.includeZeroValues = includeZeroValues
 	}
 }
 
 // WithIncludeNilValues sets whether nil values should be included in the patch.
 //
 // This is useful when you want to set a field to nil.
-func WithIncludeNilValues() PatchOpt {
+func WithIncludeNilValues(includeNilValues bool) PatchOpt {
 	return func(s *SQLPatch) {
-		s.includeNilValues = true
+		s.includeNilValues = includeNilValues
 	}
 }
 

--- a/sql_test.go
+++ b/sql_test.go
@@ -384,7 +384,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeZeroValue() {
 		Description: "",
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeZeroValues())
+	patch := NewSQLPatch(obj, WithIncludeZeroValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{int64(73), "test", ""}, patch.args)
@@ -403,7 +403,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeZeroValue_Pointer() {
 		Description: ptr(""),
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeZeroValues())
+	patch := NewSQLPatch(obj, WithIncludeZeroValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{int64(73), "test", ""}, patch.args)
@@ -422,7 +422,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeZeroValue_PointerNil()
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeZeroValues())
+	patch := NewSQLPatch(obj, WithIncludeZeroValues(true))
 
 	// Nothing should be included as we are including zero values and all fields are nil
 	s.Empty(patch.fields)
@@ -442,7 +442,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue() {
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{nil, nil, nil}, patch.args)
@@ -461,7 +461,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue_Pointer() {
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{nil, nil, nil}, patch.args)
@@ -480,7 +480,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue_PointerWithVa
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{int64(73), "test", nil}, patch.args)
@@ -499,7 +499,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue_PointerWithZe
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{int64(0), "test", nil}, patch.args)
@@ -518,7 +518,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue_PointerWithZe
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{int64(0), nil, nil}, patch.args)
@@ -537,7 +537,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue_PointerWithZe
 		Description: ptr("desc"),
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{int64(0), nil, "desc"}, patch.args)
@@ -556,7 +556,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IncludeNilValue_IncludeZeroVa
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues(), WithIncludeZeroValues())
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true), WithIncludeZeroValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{nil, "", nil}, patch.args)
@@ -578,7 +578,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_WithDB() {
 	// Setup mock database
 	db := &sql.DB{}
 
-	patch := NewSQLPatch(obj, WithDB(db), WithIncludeNilValues(), WithIncludeZeroValues())
+	patch := NewSQLPatch(obj, WithDB(db), WithIncludeNilValues(true), WithIncludeZeroValues(true))
 
 	s.Equal([]string{"id = ?", "name = ?", "description = ?"}, patch.fields)
 	s.Equal([]any{nil, "", nil}, patch.args)
@@ -599,7 +599,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IgnoredFields() {
 		Description: nil,
 	}
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues(), WithIncludeZeroValues(), WithIgnoredFields("Id", "Description"))
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true), WithIncludeZeroValues(true), WithIgnoredFields("Id", "Description"))
 
 	s.Equal([]string{"name = ?"}, patch.fields)
 	s.Equal([]any{""}, patch.args)
@@ -623,7 +623,7 @@ func (s *newSQLPatchSuite) TestNewSQLPatch_Success_IgnoredFieldsFunc() {
 		return field.Name == "Id" || field.Name == "Description"
 	})
 
-	patch := NewSQLPatch(obj, WithIncludeNilValues(), WithIncludeZeroValues(), WithIgnoredFieldsFunc(ignoreFunc.Execute))
+	patch := NewSQLPatch(obj, WithIncludeNilValues(true), WithIncludeZeroValues(true), WithIgnoredFieldsFunc(ignoreFunc.Execute))
 
 	s.Equal([]string{"name = ?"}, patch.fields)
 	s.Equal([]any{""}, patch.args)
@@ -1080,7 +1080,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesZeroValues() {
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeZeroValues(),
+		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1106,7 +1106,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesZeroValues_Pointer() 
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeZeroValues(),
+		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1132,7 +1132,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesZeroValues_PointerNil
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeZeroValues(),
+		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
 	s.True(errors.Is(err, ErrNoFields))
@@ -1158,7 +1158,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues() {
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
+		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1184,7 +1184,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_Pointer() {
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
+		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1210,7 +1210,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_PointerWith
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
+		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1236,7 +1236,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_PointerWith
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
+		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1262,7 +1262,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_PointerWith
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
+		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1288,8 +1288,8 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
-		WithIncludeZeroValues(),
+		WithIncludeNilValues(true),
+		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1315,8 +1315,8 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
-		WithIncludeZeroValues(),
+		WithIncludeNilValues(true),
+		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1342,8 +1342,8 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 
 	sqlStr, args, err := GenerateSQL(obj,
 		WithTable("test_table"),
-		WithIncludeNilValues(),
-		WithIncludeZeroValues(),
+		WithIncludeNilValues(true),
+		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
 	s.NoError(err)
@@ -1670,7 +1670,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeZeroVal
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{73})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues(true))
 	s.NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
@@ -1705,7 +1705,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeZeroVal
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{73})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues(true))
 	s.NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
@@ -1737,7 +1737,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeZeroVal
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{1})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues(true))
 	s.True(errors.Is(err, ErrNoChanges))
 	s.Nil(patch)
 }
@@ -1764,7 +1764,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{1})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true))
 	s.NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
@@ -1796,7 +1796,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{1})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true))
 	s.NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
@@ -1828,7 +1828,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{1})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true))
 	s.NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
@@ -1863,7 +1863,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw := NewMockWherer(s.T())
 	mw.On("Where").Return("id = ?", []any{1})
 
-	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(), WithIncludeZeroValues())
+	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true), WithIncludeZeroValues(true))
 	s.NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes updates to the patcher options to allow specifying whether to include zero and nil values. The changes affect various parts of the codebase, including examples, patch options, and tests.

### Changes to patcher options:

* [`patch_opts.go`](diffhunk://#diff-ca0fec26dd2c06d9588e6e74cdb66b52865144f1d27e76179ab8364dff4ba271L95-R106): Modified `WithIncludeZeroValues` and `WithIncludeNilValues` functions to accept a boolean parameter to specify whether to include zero and nil values.

### Updates to examples:

* [`examples/basic_with_opts/main.go`](diffhunk://#diff-1ca44a8bf1e50aaf6ed31c1c872526e35fbcd27adf61fd4a113a05d83d50bde9L50-R51): Updated calls to `WithIncludeZeroValues` and `WithIncludeNilValues` to pass `true` as an argument.
* [`examples/loader_with_opts/main.go`](diffhunk://#diff-dbd94054314c72afb50f3c35a2a1f7830078ce7078ac4871371c62c704c0abc8L53-R54): Updated calls to `WithIncludeZeroValues` and `WithIncludeNilValues` to pass `true` as an argument.

### Modifications in tests:

* [`sql_test.go`](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L387-R387): Updated various test functions to pass `true` to `WithIncludeZeroValues` and `WithIncludeNilValues`. [[1]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L387-R387) [[2]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L406-R406) [[3]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L425-R425) [[4]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L445-R445) [[5]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L464-R464) [[6]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L483-R483) [[7]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L502-R502) [[8]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L521-R521) [[9]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L540-R540) [[10]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L559-R559) [[11]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L581-R581) [[12]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L602-R602) [[13]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L626-R626) [[14]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1083-R1083) [[15]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1109-R1109) [[16]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1135-R1135) [[17]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1161-R1161) [[18]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1187-R1187) [[19]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1213-R1213) [[20]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1239-R1239) [[21]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1265-R1265) [[22]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1291-R1292) [[23]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1318-R1319) [[24]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1345-R1346) [[25]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1673-R1673) [[26]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1708-R1708) [[27]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1740-R1740) [[28]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1767-R1767) [[29]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1799-R1799) [[30]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1831-R1831) [[31]](diffhunk://#diff-17bc689aadd86f775f381358643a3a2a2de60da31044b8580333d18ae16ab9f5L1866-R1866)