### PR TITLE
chore(inserter): adding a parameter to specify the include pk field for the inserter

### DIFF
--- a/inserter/batch_opts.go
+++ b/inserter/batch_opts.go
@@ -44,8 +44,8 @@ func WithIgnoreFieldsFunc(f patcher.IgnoreFieldsFunc) BatchOpt {
 }
 
 // WithIncludePrimaryKey determines whether the primary key should be included in the insert
-func WithIncludePrimaryKey() BatchOpt {
+func WithIncludePrimaryKey(includePrimaryKey bool) BatchOpt {
 	return func(b *SQLBatch) {
-		b.includePrimaryKey = true
+		b.includePrimaryKey = includePrimaryKey
 	}
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a change to the `WithIncludePrimaryKey` function in the `inserter/batch_opts.go` file to make it more flexible by allowing the caller to specify whether to include the primary key.

Function modification:

* [`inserter/batch_opts.go`](diffhunk://#diff-95f39f07ab3c945383aedab0adfae0220affb956f82a1d208450e31f608b59adL47-R49): The `WithIncludePrimaryKey` function has been updated to accept a boolean parameter `includePrimaryKey`, which allows the caller to specify whether the primary key should be included in the insert.