### PR TITLE
chore(inserter): simplifying test case

### DIFF
--- a/inserter/sql_test.go
+++ b/inserter/sql_test.go
@@ -62,15 +62,7 @@ func (s *newBatchSuite) TestNewBatch_Success_IgnorePK() {
 	s.Require().Len(b.Fields(), 1)
 	s.Require().Len(b.Args(), 5)
 
-	s.Condition(func() bool {
-		for _, f := range b.Fields() {
-			if f == "id" {
-				return false
-			}
-		}
-
-		return true
-	})
+	s.NotContains(b.Fields(), "id")
 }
 
 func (s *newBatchSuite) TestNewBatch_Success_IncludePK() {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `inserter/sql_test.go` file. The change simplifies the test assertion in the `TestNewBatch_Success_IgnorePK` function by replacing a custom condition with the `NotContains` method.

* [`inserter/sql_test.go`](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L65-R65): Simplified the test assertion in the `TestNewBatch_Success_IgnorePK` function by replacing a custom condition with the `NotContains` method.