### PR TITLE
chore(inserter): Simplifying the inserter package

### DIFF
--- a/inserter/sql.go
+++ b/inserter/sql.go
@@ -76,7 +76,7 @@ func (b *SQLBatch) getFieldValue(v reflect.Value, f *reflect.StructField) any {
 	return v.Interface()
 }
 
-func (b *SQLBatch) GenerateSQL() (string, []any, error) {
+func (b *SQLBatch) GenerateSQL() (sqlStr string, args []any, err error) {
 	if err := b.validateSQLGen(); err != nil {
 		return "", nil, err
 	}

--- a/inserter/sql.go
+++ b/inserter/sql.go
@@ -12,13 +12,10 @@ import (
 
 func NewBatch(resources []any, opts ...BatchOpt) *SQLBatch {
 	b := newBatchDefaults(opts...)
-
 	for _, opt := range opts {
 		opt(b)
 	}
-
 	b.genBatch(resources)
-
 	return b
 }
 
@@ -26,67 +23,46 @@ func (b *SQLBatch) genBatch(resources []any) {
 	uniqueFields := make(map[string]struct{})
 
 	for _, r := range resources {
-		// get the type of the resource
 		t := reflect.TypeOf(r)
 		if t.Kind() == reflect.Ptr {
 			t = t.Elem()
 		}
-
-		// Is the type a struct?
 		if t.Kind() != reflect.Struct {
 			continue
 		}
 
-		// get the value of the resource
 		v := reflect.ValueOf(r)
 		if v.Kind() == reflect.Ptr {
 			v = v.Elem()
 		}
 
-		// get the fields
-		for i := 0; i < t.NumField(); i++ {
+		for i := range t.NumField() {
+			if !patcher.IsValidType(v.Field(i)) {
+				continue
+			}
+
 			f := t.Field(i)
+			if !f.IsExported() || b.checkSkipField(&f) {
+				continue
+			}
+
 			tag := f.Tag.Get(b.tagName)
 			if tag == patcher.TagOptSkip {
 				continue
 			}
 
-			tags := strings.Split(tag, patcher.TagOptSeparator)
-			if len(tags) > 1 {
-				tag = tags[0]
-			}
-
-			// Skip unexported fields
-			if !f.IsExported() {
-				continue
-			}
-
-			// Skip fields that are to be ignored
-			if b.checkSkipField(&f) {
-				continue
-			}
-
-			patcherOptsTag := f.Tag.Get(patcher.TagOptsName)
-			if patcherOptsTag != "" {
-				patcherOpts := strings.Split(patcherOptsTag, patcher.TagOptSeparator)
-				if slices.Contains(patcherOpts, patcher.TagOptSkip) {
-					continue
-				}
-			}
-
-			// if no tag is set, use the field name
 			if tag == "" {
 				tag = f.Name
+			} else {
+				tag = strings.Split(tag, patcher.TagOptSeparator)[0]
 			}
 
 			b.args = append(b.args, b.getFieldValue(v.Field(i), &f))
 
-			// if the field is not unique, skip it
 			if _, ok := uniqueFields[tag]; ok {
 				continue
 			}
 
-			// add the field to the list
 			b.fields = append(b.fields, tag)
 			uniqueFields[tag] = struct{}{}
 		}
@@ -94,40 +70,28 @@ func (b *SQLBatch) genBatch(resources []any) {
 }
 
 func (b *SQLBatch) getFieldValue(v reflect.Value, f *reflect.StructField) any {
-	if f.Type.Kind() == reflect.Ptr {
-		if v.IsNil() {
-			return nil
-		}
-		return v.Elem().Interface()
+	if f.Type.Kind() == reflect.Ptr && v.IsNil() {
+		return nil
 	}
-
 	return v.Interface()
 }
 
-func (b *SQLBatch) GenerateSQL() (sqlStr string, args []any, err error) {
+func (b *SQLBatch) GenerateSQL() (string, []any, error) {
 	if err := b.validateSQLGen(); err != nil {
 		return "", nil, err
 	}
 
 	sqlBuilder := new(strings.Builder)
-
 	sqlBuilder.WriteString("INSERT INTO ")
 	sqlBuilder.WriteString(b.table)
 	sqlBuilder.WriteString(" (")
 	sqlBuilder.WriteString(strings.Join(b.fields, ", "))
 	sqlBuilder.WriteString(") VALUES ")
 
-	// We need to have the same number of "?" as fields and then repeat that for the number of resources
 	placeholder := strings.Repeat("?, ", len(b.fields))
-	placeholder = placeholder[:len(placeholder)-2] // Remove the trailing ", "
-	placeholder = "(" + placeholder + "), "
-
-	// Calculate the number of placeholders needed. Args divided by fields
-	n := len(b.args) / len(b.fields)
-
-	// Repeat the placeholder for the number of resources
-	placeholders := strings.Repeat(placeholder, n)
-	sqlBuilder.WriteString(placeholders[:len(placeholders)-2]) // Remove the trailing ", " and add the closing ")"
+	placeholder = "(" + placeholder[:len(placeholder)-2] + "), "
+	placeholders := strings.Repeat(placeholder, len(b.args)/len(b.fields))
+	sqlBuilder.WriteString(placeholders[:len(placeholders)-2])
 
 	return sqlBuilder.String(), b.args, nil
 }
@@ -146,17 +110,7 @@ func (b *SQLBatch) Perform() (sql.Result, error) {
 }
 
 func (b *SQLBatch) checkSkipField(field *reflect.StructField) bool {
-	// The ignore fields tag takes precedence over the ignore fields list
-	if b.checkSkipTag(field) {
-		return true
-	}
-
-	// Check if the field is a primary key, we don't want to include the primary key in the insert unless specified
-	if b.checkPrimaryKey(field) {
-		return true
-	}
-
-	return b.ignoredFieldsCheck(field)
+	return b.checkSkipTag(field) || b.checkPrimaryKey(field) || b.ignoredFieldsCheck(field)
 }
 
 func (b *SQLBatch) checkSkipTag(field *reflect.StructField) bool {
@@ -164,24 +118,18 @@ func (b *SQLBatch) checkSkipTag(field *reflect.StructField) bool {
 	if !ok {
 		return false
 	}
-
-	tags := strings.Split(val, patcher.TagOptSeparator)
-	return slices.Contains(tags, patcher.TagOptSkip)
+	return slices.Contains(strings.Split(val, patcher.TagOptSeparator), patcher.TagOptSkip)
 }
 
 func (b *SQLBatch) checkPrimaryKey(field *reflect.StructField) bool {
-	// If we are including the primary key, we can immediately return false
 	if b.includePrimaryKey {
 		return false
 	}
-
 	val, ok := field.Tag.Lookup(patcher.DefaultDbTagName)
 	if !ok {
 		return false
 	}
-
-	tags := strings.Split(val, patcher.TagOptSeparator)
-	return slices.Contains(tags, patcher.DBTagPrimaryKey)
+	return slices.Contains(strings.Split(val, patcher.TagOptSeparator), patcher.DBTagPrimaryKey)
 }
 
 func (b *SQLBatch) ignoredFieldsCheck(field *reflect.StructField) bool {

--- a/inserter/sql_test.go
+++ b/inserter/sql_test.go
@@ -408,7 +408,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields() {
 
 	s.Equal("INSERT INTO temp (id, name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 
-	expectedArgs := []any{1, "test", any(nil), "test2", 3, "test3", 4, "test4", 5, "test5"}
+	expectedArgs := []any{ptr(1), ptr("test"), nil, ptr("test2"), ptr(3), ptr("test3"), ptr(4), ptr("test4"), ptr(5), ptr("test5")}
 	s.Require().Equal(expectedArgs, args)
 }
 
@@ -432,7 +432,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields_noDbTag() {
 
 	s.Equal("INSERT INTO temp (ID, Name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 
-	expectedArgs := []any{1, "test", any(nil), "test2", 3, "test3", 4, "test4", 5, "test5"}
+	expectedArgs := []any{ptr(1), ptr("test"), any(nil), ptr("test2"), ptr(3), ptr("test3"), ptr(4), ptr("test4"), ptr(5), ptr("test5")}
 	s.Require().Equal(expectedArgs, args)
 }
 

--- a/patch.go
+++ b/patch.go
@@ -179,7 +179,7 @@ func (s *SQLPatch) shouldOmitEmpty(tag string) bool {
 }
 
 func (s *SQLPatch) shouldSkipField(fType *reflect.StructField, fVal reflect.Value) bool {
-	if !fType.IsExported() || !isValidType(fVal) || s.checkSkipField(fType) {
+	if !fType.IsExported() || !IsValidType(fVal) || s.checkSkipField(fType) {
 		return true
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -53,8 +53,8 @@ func getValue(fVal reflect.Value) any {
 	return fVal.Interface()
 }
 
-// isValidType checks if the given value is of a type that can be stored as a database field.
-func isValidType(val reflect.Value) bool {
+// IsValidType checks if the given value is of a type that can be stored as a database field.
+func IsValidType(val reflect.Value) bool {
 	switch val.Kind() {
 	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `inserter/sql.go` file and related test files to improve code readability and functionality. The most important changes include refactoring the `genBatch` and `GenerateSQL` methods, simplifying the `checkSkipField` method, updating test cases, and making the `isValidType` function public.

Improvements to `genBatch` and `GenerateSQL` methods:

* [`inserter/sql.go`](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL15-L103): Refactored the `genBatch` method to simplify the field processing logic and the `GenerateSQL` method to streamline placeholder generation. [[1]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL15-L103) [[2]](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL113-R94)

Simplification of `checkSkipField` method:

* [`inserter/sql.go`](diffhunk://#diff-77861f93deb7ffbdf36c5335d20ea44e2bdd8dce00fd5c70cf2fb2db304a7a6bL149-R132): Simplified the `checkSkipField` method by combining multiple checks into a single return statement.

Updates to test cases:

* [`inserter/sql_test.go`](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L411-R411): Updated test cases `TestGenerateSQL_Success_WithPointedFields` and `TestGenerateSQL_Success_WithPointedFields_noDbTag` to use pointer values in the expected arguments. [[1]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L411-R411) [[2]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L435-R435)

Making utility function public:

* [`utils.go`](diffhunk://#diff-8b7f25bac2ae04c2ce2abb628c6aa28103fd113103a62f3e9d232fa995684915L56-R57): Changed the `isValidType` function to `IsValidType` to make it public and updated references accordingly. [[1]](diffhunk://#diff-8b7f25bac2ae04c2ce2abb628c6aa28103fd113103a62f3e9d232fa995684915L56-R57) [[2]](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aL182-R182)