### PR TITLE
chore(issues): removing redundant fields from issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,14 +7,6 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report! Please provide the following information to help us resolve the issue quickly.
-  - type: input
-    id: bug-title
-    attributes:
-      label: Bug Title
-      description: A brief summary of the bug.
-      placeholder: Brief summary of the bug
-    validations:
-      required: true
   - type: textarea
     id: what-happened
     attributes:
@@ -36,7 +28,10 @@ body:
     attributes:
       label: Steps to reproduce
       description: Provide detailed steps to reproduce the issue.
-      placeholder: 1. Go to '...'\n2. Click on '...'\n3. Scroll down to '...'\n4. See error
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,14 +7,6 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this feature request! Please provide the following information to help us understand your suggestion.
-  - type: input
-    id: feature-title
-    attributes:
-      label: Feature Title
-      description: A brief summary of the feature.
-      placeholder: Brief summary of the feature
-    validations:
-      required: true
   - type: textarea
     id: feature-description
     attributes:


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to the issue templates for both bug reports and feature requests. The most important changes involve the removal of the title input fields and a modification to the placeholder format for the steps to reproduce section.

Changes to bug report template:

* [`.github/ISSUE_TEMPLATE/bug.yml`](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdL10-L17): Removed the `bug-title` input field and its associated attributes and validations.
* [`.github/ISSUE_TEMPLATE/bug.yml`](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdL39-R34): Modified the placeholder format for the `steps-to-reproduce` textarea to use a multi-line string.

Changes to feature request template:

* [`.github/ISSUE_TEMPLATE/feature.yml`](diffhunk://#diff-e5e34a44eb79bba1a224849ae3f2c9f96f189ececd74323d4a42ace0c338c3b3L10-L17): Removed the `feature-title` input field and its associated attributes and validations.