### PR TITLE
chore(linters): Updating according to linters

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -89,9 +89,8 @@ func (s *SQLPatch) handleEmbeddedStruct(oField, nField reflect.Value, tag string
 	switch {
 	case !oField.IsNil() && !nField.IsNil():
 		return s.loadDiff(oField.Interface(), nField.Interface())
-	case nField.IsValid() && !nField.IsNil():
-		fallthrough
-	case nField.IsNil() && s.shouldIncludeNil(tag):
+	case nField.IsValid() && !nField.IsNil(),
+		nField.IsNil() && s.shouldIncludeNil(tag):
 		oField.Set(nField)
 	}
 

--- a/patch.go
+++ b/patch.go
@@ -190,12 +190,7 @@ func (s *SQLPatch) shouldSkipField(fType *reflect.StructField, fVal reflect.Valu
 	if fVal.Kind() != reflect.Ptr && (fVal.IsZero() && !s.shouldIncludeZero(patcherOptsTag)) {
 		return true
 	}
-	if patcherOptsTag != "" {
-		patcherOpts := strings.Split(patcherOptsTag, TagOptSeparator)
-		if slices.Contains(patcherOpts, TagOptSkip) {
-			return true
-		}
-	}
+
 	return false
 }
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to the `SQLPatch` functionality in `loader.go` and corresponding tests in `loader_test.go`. The most important changes include modifications to the handling of embedded structs, the addition of new test cases, and refactoring of the `shouldSkipField` method.

Improvements to handling embedded structs:

* [`loader.go`](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL50-R50): Updated the `handleEmbeddedStruct` method to accept an additional `tag` parameter and modified its logic to handle nil values based on the new parameter. [[1]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL50-R50) [[2]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL84-R93)

Enhancements to test coverage:

* [`loader_test.go`](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26R322-R457): Added new test cases to verify the behavior of `loadDiff` and `handleEmbeddedStruct` with various configurations of embedded structs, including deeply nested and nil values.

Codebase simplification:

* [`patch.go`](diffhunk://#diff-57f6b83ec3544fa65e2b3e830eb15f5b5bf5f232bd1b488744c56bb303b9f64aL193-R193): Refactored the `shouldSkipField` method by removing unnecessary checks for the `patcherOptsTag` parameter.