### PR TITLE
chore(sql): Updating acording to linters to reduce nesting

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -191,14 +191,17 @@ func NewDiffSQLPatch[T any](old, newT *T, opts ...PatchOpt) (*SQLPatch, error) {
 			continue
 		}
 
-		if reflect.DeepEqual(oldField.Interface(), copyField.Interface()) {
-			// Field is the same, set it to zero or nil. Add it to be ignored in the patch
-			if patch.ignoreFields == nil {
-				patch.ignoreFields = make([]string, 0)
-			}
-			patch.ignoreFields = append(patch.ignoreFields, oldElem.Type().Field(i).Name)
+		if !reflect.DeepEqual(oldField.Interface(), copyField.Interface()) {
 			continue
 		}
+
+		// Field is the same, set it to zero or nil. Add it to be ignored in the patch
+		if patch.ignoreFields == nil {
+			patch.ignoreFields = make([]string, 0)
+		}
+		patch.ignoreFields = append(patch.ignoreFields, oldElem.Type().Field(i).Name)
+		continue
+
 	}
 
 	patch.patchGen(old)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small but significant change to the `NewDiffSQLPatch` function in the `sql.go` file. The change corrects the logic for comparing fields in the `old` and `newT` structures.

* [`sql.go`](diffhunk://#diff-76c32ac737291e55d9320a4e63fb5d7d72a97ac34376bab17596e1a4531fd1c6L194-R204): Modified the condition to continue the loop when fields in `old` and `newT` are not deeply equal, ensuring that only identical fields are set to zero or nil and added to the ignored fields in the patch.