### PR TITLE
feat(examples): Adding a complex filter example

### DIFF
--- a/examples/complex_filter/README.md
+++ b/examples/complex_filter/README.md
@@ -1,190 +1,20 @@
-# Joiner
+# Complex Filter Example
 
-For this example assume that you have two tables in the database `people` and `contacts`.
+This example demonstrates how to use the `Joiner` and `Wherer` interface under the same `Filter` instance to create a
+complex filter.
 
-## People
+## Database Schema
+
+### People Table
 
 | id | name | age |
 |----|------|-----|
 | 1  | Ben  | 25  |
 | 2  | John | 30  |
 
-## Contacts
+### Contacts Table
 
 | id | person_id | email               |
 |----|-----------|---------------------|
 | 1  | 1         | ben@example.com     |
 | 2  | 2         | john@exampletwo.com |
-
-# Example
-
-Moving forwards with the example, lets assume that you are updating the person and you have received their email as the
-key on the data. You can use the `Joiner` interface to join the two tables and update the person.
-
-```go
-package main
-
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/jacobbrewer1/patcher"
-)
-
-type Person struct {
-	ID    *int    `db:"id"`
-	Name  *string `db:"name"`
-	Age   *int    `db:"age"`
-	Email *string `db:"email"`
-}
-
-type PersonWhere struct {
-	ID *int
-}
-
-func NewPersonWhere(id int) *PersonWhere {
-	return &PersonWhere{
-		ID: &id,
-	}
-}
-
-func (p *PersonWhere) Where() (string, []interface{}) {
-	return "id = ?", []interface{}{*p.ID}
-}
-
-type ContactWhere struct {
-	Email *string
-}
-
-func NewContactWhere(email string) *ContactWhere {
-	return &ContactWhere{
-		Email: &email,
-	}
-}
-
-func (c *ContactWhere) Where() (string, []interface{}) {
-	return "email = ?", []interface{}{*c.Email}
-}
-
-type PersonContactJoiner struct{}
-
-func NewPersonContactJoiner() *PersonContactJoiner {
-	return &PersonContactJoiner{}
-}
-
-func (p *PersonContactJoiner) Join() (string, []any) {
-	return "JOIN contacts c ON c.person_id = p.id", nil
-}
-
-func main() {
-	jsonStr := `{"name": "john", "age": 25, "email": "john@exampletwo.com"}`
-
-	person := new(Person)
-	if err := json.Unmarshal([]byte(jsonStr), person); err != nil {
-		panic(err)
-	}
-
-	condition := NewPersonWhere(1)
-	joiner := NewPersonContactJoiner()
-
-	sqlStr, args, err := patcher.GenerateSQL(
-		person,
-		patcher.WithTable("people"),
-		patcher.WithWhere(condition),
-		patcher.WithJoin(joiner),
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println(sqlStr)
-	fmt.Println(args)
-}
-
-```
-
-```go
-package main
-
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/jacobbrewer1/patcher"
-)
-
-type Person struct {
-	ID    *int    `db:"id"`
-	Name  *string `db:"name"`
-	Age   *int    `db:"age"`
-	Email *string `db:"email"`
-}
-
-type PersonWhere struct {
-	ID *int `db:"id"`
-}
-
-func NewPersonWhere(id int) *PersonWhere {
-	return &PersonWhere{
-		ID: &id,
-	}
-}
-
-func (p *PersonWhere) Where() (string, []interface{}) {
-	return "id = ?", []interface{}{*p.ID}
-}
-
-type ContactWhere struct {
-	Email *string
-}
-
-func NewContactWhere(email string) *ContactWhere {
-	return &ContactWhere{
-		Email: &email,
-	}
-}
-
-func (c *ContactWhere) Where() (string, []interface{}) {
-	return "email = ?", []interface{}{*c.Email}
-}
-
-type PersonContactJoiner struct {
-	Email *string
-}
-
-func NewPersonContactJoiner(email string) *PersonContactJoiner {
-	return &PersonContactJoiner{
-		Email: &email,
-	}
-}
-
-func (p *PersonContactJoiner) Join() (string, []any) {
-	return "JOIN contacts c ON c.person_id = p.id AND c.email = ?", []any{*p.Email}
-}
-
-func main() {
-	jsonStr := `{"name": "john", "age": 25, "email": "john@exampletwo.com"}`
-
-	person := new(Person)
-	if err := json.Unmarshal([]byte(jsonStr), person); err != nil {
-		panic(err)
-	}
-
-	condition := NewPersonWhere(1)
-	joiner := NewPersonContactJoiner(*person.Email)
-
-	sqlStr, args, err := patcher.GenerateSQL(
-		person,
-		patcher.WithTable("people"),
-		patcher.WithWhere(condition),
-		patcher.WithJoin(joiner),
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println(sqlStr)
-	fmt.Println(args)
-}
-
-```

--- a/examples/complex_filter/README.md
+++ b/examples/complex_filter/README.md
@@ -1,0 +1,190 @@
+# Joiner
+
+For this example assume that you have two tables in the database `people` and `contacts`.
+
+## People
+
+| id | name | age |
+|----|------|-----|
+| 1  | Ben  | 25  |
+| 2  | John | 30  |
+
+## Contacts
+
+| id | person_id | email               |
+|----|-----------|---------------------|
+| 1  | 1         | ben@example.com     |
+| 2  | 2         | john@exampletwo.com |
+
+# Example
+
+Moving forwards with the example, lets assume that you are updating the person and you have received their email as the
+key on the data. You can use the `Joiner` interface to join the two tables and update the person.
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jacobbrewer1/patcher"
+)
+
+type Person struct {
+	ID    *int    `db:"id"`
+	Name  *string `db:"name"`
+	Age   *int    `db:"age"`
+	Email *string `db:"email"`
+}
+
+type PersonWhere struct {
+	ID *int
+}
+
+func NewPersonWhere(id int) *PersonWhere {
+	return &PersonWhere{
+		ID: &id,
+	}
+}
+
+func (p *PersonWhere) Where() (string, []interface{}) {
+	return "id = ?", []interface{}{*p.ID}
+}
+
+type ContactWhere struct {
+	Email *string
+}
+
+func NewContactWhere(email string) *ContactWhere {
+	return &ContactWhere{
+		Email: &email,
+	}
+}
+
+func (c *ContactWhere) Where() (string, []interface{}) {
+	return "email = ?", []interface{}{*c.Email}
+}
+
+type PersonContactJoiner struct{}
+
+func NewPersonContactJoiner() *PersonContactJoiner {
+	return &PersonContactJoiner{}
+}
+
+func (p *PersonContactJoiner) Join() (string, []any) {
+	return "JOIN contacts c ON c.person_id = p.id", nil
+}
+
+func main() {
+	jsonStr := `{"name": "john", "age": 25, "email": "john@exampletwo.com"}`
+
+	person := new(Person)
+	if err := json.Unmarshal([]byte(jsonStr), person); err != nil {
+		panic(err)
+	}
+
+	condition := NewPersonWhere(1)
+	joiner := NewPersonContactJoiner()
+
+	sqlStr, args, err := patcher.GenerateSQL(
+		person,
+		patcher.WithTable("people"),
+		patcher.WithWhere(condition),
+		patcher.WithJoin(joiner),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(sqlStr)
+	fmt.Println(args)
+}
+
+```
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jacobbrewer1/patcher"
+)
+
+type Person struct {
+	ID    *int    `db:"id"`
+	Name  *string `db:"name"`
+	Age   *int    `db:"age"`
+	Email *string `db:"email"`
+}
+
+type PersonWhere struct {
+	ID *int `db:"id"`
+}
+
+func NewPersonWhere(id int) *PersonWhere {
+	return &PersonWhere{
+		ID: &id,
+	}
+}
+
+func (p *PersonWhere) Where() (string, []interface{}) {
+	return "id = ?", []interface{}{*p.ID}
+}
+
+type ContactWhere struct {
+	Email *string
+}
+
+func NewContactWhere(email string) *ContactWhere {
+	return &ContactWhere{
+		Email: &email,
+	}
+}
+
+func (c *ContactWhere) Where() (string, []interface{}) {
+	return "email = ?", []interface{}{*c.Email}
+}
+
+type PersonContactJoiner struct {
+	Email *string
+}
+
+func NewPersonContactJoiner(email string) *PersonContactJoiner {
+	return &PersonContactJoiner{
+		Email: &email,
+	}
+}
+
+func (p *PersonContactJoiner) Join() (string, []any) {
+	return "JOIN contacts c ON c.person_id = p.id AND c.email = ?", []any{*p.Email}
+}
+
+func main() {
+	jsonStr := `{"name": "john", "age": 25, "email": "john@exampletwo.com"}`
+
+	person := new(Person)
+	if err := json.Unmarshal([]byte(jsonStr), person); err != nil {
+		panic(err)
+	}
+
+	condition := NewPersonWhere(1)
+	joiner := NewPersonContactJoiner(*person.Email)
+
+	sqlStr, args, err := patcher.GenerateSQL(
+		person,
+		patcher.WithTable("people"),
+		patcher.WithWhere(condition),
+		patcher.WithJoin(joiner),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(sqlStr)
+	fmt.Println(args)
+}
+
+```

--- a/examples/complex_filter/main.go
+++ b/examples/complex_filter/main.go
@@ -14,31 +14,23 @@ type Person struct {
 	Email *string `db:"email"`
 }
 
-type PersonWhere struct {
-	ID *int `db:"id"`
+type PersonFilter struct {
+	ID    *int    `db:"id"`
+	Email *string `db:"email"`
 }
 
-func NewPersonWhere(id int) patcher.Wherer {
-	return &PersonWhere{
-		ID: &id,
-	}
-}
-
-func (p *PersonWhere) Where() (string, []interface{}) {
-	return "id = ?", []interface{}{*p.ID}
-}
-
-type PersonContactJoiner struct {
-	Email *string
-}
-
-func NewPersonContactJoiner(email string) patcher.Joiner {
-	return &PersonContactJoiner{
+func NewPersonFilter(id int, email string) patcher.Filter {
+	return &PersonFilter{
+		ID:    &id,
 		Email: &email,
 	}
 }
 
-func (p *PersonContactJoiner) Join() (string, []any) {
+func (p *PersonFilter) Where() (string, []interface{}) {
+	return "id = ?", []interface{}{*p.ID}
+}
+
+func (p *PersonFilter) Join() (string, []any) {
 	return "JOIN contacts c ON c.person_id = p.id AND c.email = ?", []any{*p.Email}
 }
 
@@ -50,14 +42,12 @@ func main() {
 		panic(err)
 	}
 
-	condition := NewPersonWhere(1)
-	joiner := NewPersonContactJoiner(*person.Email)
+	condition := NewPersonFilter(1, *person.Email)
 
 	sqlStr, args, err := patcher.GenerateSQL(
 		person,
 		patcher.WithTable("people"),
-		patcher.WithWhere(condition),
-		patcher.WithJoin(joiner),
+		patcher.WithFilter(condition),
 	)
 	if err != nil {
 		panic(err)

--- a/multifilter.go
+++ b/multifilter.go
@@ -2,9 +2,13 @@ package patcher
 
 import "strings"
 
-type MultiFilter interface {
+type Filter interface {
 	Joiner
 	Wherer
+}
+
+type MultiFilter interface {
+	Filter
 	Add(filter any)
 }
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces a new example for creating complex filters using the `Joiner` and `Wherer` interfaces and makes several changes to the codebase to support this functionality. The most important changes include the addition of a new example, modifications to existing filter interfaces, and updates to the `patcher` package.

### New Example Addition:
* [`examples/complex_filter/README.md`](diffhunk://#diff-6fbe985d137f3a61a48950e3a0c55e2f7871fe6f70ed410fee4d64fb53f69e46R1-R20): Added a new README file that explains how to use the `Joiner` and `Wherer` interfaces to create a complex filter. This includes a database schema for the `People` and `Contacts` tables.
* [`examples/complex_filter/main.go`](diffhunk://#diff-80ed9cf8337fd5eadf92abc4a52f19c20a9c9bea3db51c3d6dc7890238cbddfaR1-R58): Added a new Go file that demonstrates the creation of a complex filter using the `patcher` package. This includes defining `Person` and `PersonFilter` structs, implementing the `Where` and `Join` methods, and generating SQL queries.

### Interface Modifications:
* [`examples/joiner/main.go`](diffhunk://#diff-7cc16f8a0b3ae000a8b8469b9e67439375518e2608fba56084125fd0a7a2e779L21-R21): Updated the `NewPersonWhere` and `NewPersonContactJoiner` functions to return `patcher.Wherer` and `patcher.Joiner` interfaces, respectively. Removed the `ContactWhere` struct and its associated methods. [[1]](diffhunk://#diff-7cc16f8a0b3ae000a8b8469b9e67439375518e2608fba56084125fd0a7a2e779L21-R21) [[2]](diffhunk://#diff-7cc16f8a0b3ae000a8b8469b9e67439375518e2608fba56084125fd0a7a2e779L31-R35)

### Patcher Package Updates:
* [`multifilter.go`](diffhunk://#diff-3262e86d1549095cd309f6f3b377d0ce864bf5c13ca0ec0bc47a0f213a4179d2L5-R11): Modified the `MultiFilter` interface to embed the new `Filter` interface, which combines the `Joiner` and `Wherer` interfaces.