### PR TITLE
chore(cicd): updating the cicd to include the testify lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - thelper
     - tparallel
     - intrange
+    - testifylint
 issues:
   exclude-rules:
     - path: (.+)_test.go
@@ -142,3 +143,5 @@ linters-settings:
     enable:
       - identical # Identifies interfaces in the same package that have identical method sets.
       - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+  testifylint:
+    enable-all: true

--- a/inserter/sql_test.go
+++ b/inserter/sql_test.go
@@ -162,8 +162,8 @@ func (s *newBatchSuite) TestNewBatch_notStruct() {
 
 	b := NewBatch(resources, WithTable("temp"), WithTagName("db"))
 
-	s.Len(b.Fields(), 0)
-	s.Len(b.Args(), 0)
+	s.Require().Empty(b.Fields())
+	s.Require().Empty(b.Args())
 }
 
 func (s *newBatchSuite) TestNewBatch_noFields() {
@@ -181,15 +181,15 @@ func (s *newBatchSuite) TestNewBatch_noFields() {
 
 	b := NewBatch(resources, WithTable("temp"), WithTagName("db"))
 
-	s.Len(b.Fields(), 0)
-	s.Len(b.Args(), 0)
+	s.Require().Empty(b.Fields())
+	s.Require().Empty(b.Args())
 }
 
 func (s *newBatchSuite) TestNewBatch_noResources() {
 	b := NewBatch(nil, WithTable("temp"), WithTagName("db"))
 
-	s.Len(b.Fields(), 0)
-	s.Len(b.Args(), 0)
+	s.Require().Empty(b.Fields())
+	s.Require().Empty(b.Args())
 }
 
 func (s *newBatchSuite) TestNewBatch_noTable() {
@@ -216,8 +216,8 @@ func (s *newBatchSuite) TestNewBatch_noTable() {
 func (s *newBatchSuite) TestNewBatch_noTable_noResources() {
 	b := NewBatch(nil, WithTagName("db"))
 
-	s.Len(b.Fields(), 0)
-	s.Len(b.Args(), 0)
+	s.Require().Empty(b.Fields())
+	s.Require().Empty(b.Args())
 }
 
 type generateSQLSuite struct {
@@ -244,7 +244,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success() {
 	}
 
 	sql, args, err := NewBatch(resources, WithTable("temp"), WithTagName("db")).GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (id, name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 	s.Len(args, 10)
@@ -266,7 +266,7 @@ func (s *generateSQLSuite) TestGenerateSQL_noDbTag() {
 	}
 
 	sql, args, err := NewBatch(resources, WithTable("temp")).GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (ID, Name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 	s.Len(args, 10)
@@ -288,7 +288,7 @@ func (s *generateSQLSuite) TestGenerateSQL_notPointer() {
 	}
 
 	sql, args, err := NewBatch(resources, WithTable("temp"), WithTagName("db")).GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (id, name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 	s.Len(args, 10)
@@ -307,7 +307,7 @@ func (s *generateSQLSuite) TestGenerateSQL_notStruct() {
 	s.Equal(ErrNoFields, err)
 
 	s.Equal("", sql)
-	s.Len(args, 0)
+	s.Require().Empty(args)
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_noFields() {
@@ -327,7 +327,7 @@ func (s *generateSQLSuite) TestGenerateSQL_noFields() {
 	s.Equal(ErrNoFields, err)
 
 	s.Equal("", sql)
-	s.Len(args, 0)
+	s.Require().Empty(args)
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_noResources() {
@@ -335,7 +335,7 @@ func (s *generateSQLSuite) TestGenerateSQL_noResources() {
 	s.Equal(ErrNoFields, err)
 
 	s.Equal("", sql)
-	s.Len(args, 0)
+	s.Empty(args)
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_noTable() {
@@ -357,7 +357,7 @@ func (s *generateSQLSuite) TestGenerateSQL_noTable() {
 	s.Equal(ErrNoTable, err)
 
 	s.Equal("", sql)
-	s.Len(args, 0)
+	s.Empty(args)
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_noTable_noResources() {
@@ -365,7 +365,7 @@ func (s *generateSQLSuite) TestGenerateSQL_noTable_noResources() {
 	s.Equal(ErrNoFields, err)
 
 	s.Equal("", sql)
-	s.Len(args, 0)
+	s.Empty(args)
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_noTable_noFields() {
@@ -385,7 +385,7 @@ func (s *generateSQLSuite) TestGenerateSQL_noTable_noFields() {
 	s.Equal(ErrNoFields, err)
 
 	s.Equal("", sql)
-	s.Len(args, 0)
+	s.Empty(args)
 }
 
 func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields() {
@@ -404,7 +404,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields() {
 	}
 
 	sql, args, err := NewBatch(resources, WithTable("temp"), WithTagName("db")).GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (id, name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 
@@ -428,7 +428,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WithPointedFields_noDbTag() {
 	}
 
 	sql, args, err := NewBatch(resources, WithTable("temp")).GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (ID, Name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 
@@ -454,7 +454,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IgnoredFields() {
 	b := NewBatch(resources, WithTable("temp"), WithTagName("db"), WithIgnoreFields("unexported"))
 
 	sql, args, err := b.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (id, name) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)", sql)
 	s.Len(args, 10)
@@ -483,7 +483,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IgnoredFieldsFunc() {
 	b := NewBatch(resources, WithTable("temp"), WithTagName("db"), WithIgnoreFieldsFunc(mif.Execute))
 
 	sql, args, err := b.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("INSERT INTO temp (name) VALUES (?), (?), (?), (?), (?)", sql)
 	s.Len(args, 5)

--- a/loader_test.go
+++ b/loader_test.go
@@ -43,7 +43,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(26, old.Age)
 }
@@ -65,7 +65,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_StructOpt_IncludeNilField() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Nil(old.Age)
 }
@@ -87,7 +87,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_StructOpt_IncludeZeroField() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(0, old.Age)
 }
@@ -109,7 +109,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_NoStructOpts() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(25, old.Age)
 }
@@ -131,7 +131,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Pointed_Fields() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(25, old.Age)
 }
@@ -153,7 +153,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_ZeroValue() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(25, old.Age)
 }
@@ -172,7 +172,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_NoNewValue() {
 	n := testStruct{}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 }
@@ -193,7 +193,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_OneNewField() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(26, old.Age)
 }
@@ -218,7 +218,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_EmbeddedStruct() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 	s.Equal("Sarah", old.Partner.Name)
@@ -249,7 +249,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_EmbeddedStruct_Reverse() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 	s.Equal("Sarah Thompson", old.Partner.Name)
@@ -281,7 +281,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_EmbeddedStruct_NotPointed() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 	s.Equal("Sarah", old.Partner.Name)
@@ -313,7 +313,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_InheritedStruct_NotPointed() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(26, old.Age)
 	s.Equal("Some description", old.Description)
@@ -344,7 +344,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_InheritedStruct_Pointed() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(26, old.Age)
 	s.Equal("Some description", old.Description)
@@ -381,7 +381,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_DeeplyInheritedStruct_Pointed() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(26, old.Age)
 	s.Equal("Some description", old.Description)
@@ -420,7 +420,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_DeeplyInheritedStruct_Pointed_SetNi
 
 	s.patch.includeNilValues = true
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(26, old.Age)
 	s.Equal((*TestEmbed2)(nil), old.TestEmbed2)
@@ -451,7 +451,7 @@ func (s *loadDiffSuite) TestHandleEmbeddedStruct_ValidNonNilField() {
 	}
 
 	err := s.patch.handleEmbeddedStruct(reflect.ValueOf(&old).Elem().FieldByName("Embedded"), reflect.ValueOf(&n).Elem().FieldByName("Embedded"), "")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("Some description", old.Description)
 }
 
@@ -479,7 +479,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_EmbeddedStructWithNewValue() {
 	n.Partner.Age = 25
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(25, old.Age)
 	s.Equal("Sarah Brewer", old.Partner.Name)
@@ -516,7 +516,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_EmbeddedInheritedStruct() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(26, old.Age)
 	s.Equal("Sarah", old.Partner.Name)
@@ -540,7 +540,7 @@ func (s *loadDiffSuite) TestLoadDiff_FailureNotPointer() {
 	}
 
 	err := s.patch.loadDiff(old, n)
-	s.Error(err)
+	s.Require().Error(err)
 	s.Equal(ErrInvalidType, err)
 }
 
@@ -566,7 +566,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_NilOldField() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 	s.Equal("Sarah", old.Partner.Name)
@@ -588,7 +588,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Slice() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal([]string{"tag3"}, old.Tags) // New slice overwrites old one
 }
 
@@ -621,7 +621,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_DeeplyNestedStruct() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("New Value", old.Inner.InnerMost.Value)
 }
 
@@ -643,7 +643,7 @@ func (s *loadDiffSuite) TestLoadDiff_Failure_UnexportedField() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(26, old.Age)
 	s.Equal("OldName", old.name) // Name should remain unchanged because it's unexported
 }
@@ -665,7 +665,7 @@ func (s *loadDiffSuite) TestLoadDiff_Failure_UnsupportedType() {
 	}
 
 	err := s.patch.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.NotNil(old.Updates) // Channel should not be nil as it started as a non-nil channel
 }
@@ -690,7 +690,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Include_Zeros() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(0, old.Age)
 }
@@ -715,7 +715,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Include_Zeros_false() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John Smith", old.Name)
 	s.Equal(25, old.Age)
 }
@@ -744,7 +744,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Include_Nil() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 	s.Nil(old.Partner)
@@ -774,7 +774,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Include_Nil_false() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(25, old.Age)
 	s.Equal("Sarah", old.Partner.Name)
@@ -801,7 +801,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFields() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(26, old.Age)
 }
@@ -828,7 +828,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFieldsFunc() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(26, old.Age)
 }
@@ -856,7 +856,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_IgnoreFieldsFuncAndIgnoreFields() {
 	}
 
 	err := l.loadDiff(&old, &n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("John", old.Name)
 	s.Equal(26, old.Age)
 }
@@ -885,7 +885,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Blank_Except_Id() {
 	}
 
 	err := l.loadDiff(old, n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(17345, old.ID)
 	s.Equal("", old.Name)
 	s.Equal(25, *old.Age)
@@ -918,7 +918,7 @@ func (s *loadDiffSuite) TestLoadDiff_Success_Skip_Priority_Check() {
 	}
 
 	err := l.loadDiff(old, n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(17345, old.ID)
 	s.Equal("some text", old.Name)
 	s.Equal(25, *old.Age)
@@ -948,7 +948,7 @@ func (s *loadDiffSuite) TestLoadDiff_DefaultBehaviour() {
 	}
 
 	err := LoadDiff(old, n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(17345, old.ID)
 	s.Equal("John Smith", old.Name)
 	s.Equal(25, *old.Age)
@@ -981,7 +981,7 @@ func (s *loadDiffSuite) TestLoadDiff_IgnoreTags() {
 	}
 
 	err := LoadDiff(old, n)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(17345, old.ID)
 	s.Equal("some text", old.Name)
 	s.Equal(25, *old.Age)

--- a/sql_test.go
+++ b/sql_test.go
@@ -2,7 +2,6 @@ package patcher
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -680,7 +679,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success() {
 		WithTable("test_table"),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 
@@ -712,7 +711,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WhereAndJoin() {
 		WithTable("test_table"),
 		WithFilter(new(testFilter)),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 }
@@ -732,7 +731,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_WhereString() {
 		WithTable("test_table"),
 		WithWhereStr("age = ?", 18),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 }
@@ -756,7 +755,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_JoinString() {
 		WithJoinStr("JOIN table2 ON table1.id = table2.id"),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 
@@ -781,7 +780,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_NoWhereArgs() {
 		WithTable("test_table"),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage > 18\n)", sqlStr)
 	s.Equal([]any{1, "test"}, args)
 
@@ -806,7 +805,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_Stuct_opt_IncludeNilFields() 
 		WithTable("test_table"),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, nil, 18}, args)
 
@@ -831,7 +830,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_Struct_opt_IncludeZeroFields(
 		WithTable("test_table"),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "", 18}, args)
 
@@ -860,7 +859,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_multipleWhere() {
 		WithWhere(mw),
 		WithWhere(mw2),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\nAND name = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18, "john"}, args)
 
@@ -892,7 +891,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_orWhere() {
 		WithWhere(mw),
 		WithWhere(mw2),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\nOR name = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18, "john"}, args)
 
@@ -926,7 +925,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_andOrWhere() {
 		WithWhere(mw2),
 		WithWhere(mw3),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\nOR name = ?\nAND id = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18, "john", 1}, args)
 
@@ -956,7 +955,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_invalidWhereType() {
 		WithWhere(mw),
 		WithWhere(mw2),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\nAND name = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18, "john"}, args)
 
@@ -985,7 +984,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoin() {
 		WithWhere(mw),
 		WithJoin(mj),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 
@@ -1018,7 +1017,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_multipleJoin() {
 		WithJoin(mj),
 		WithJoin(mj2),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nJOIN table3 ON table1.id = table3.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 
@@ -1047,7 +1046,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoinAndWhere() {
 		WithWhere(mw),
 		WithJoin(mj),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 
@@ -1080,7 +1079,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_withJoinAndWhereAndJoin() {
 		WithJoin(mj),
 		WithJoin(mj2),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nJOIN table2 ON table1.id = table2.id\nJOIN table3 ON table1.id = table3.id\nSET id = ?, name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{1, "test", 18}, args)
 
@@ -1108,7 +1107,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesZeroValues() {
 		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{73, "test", "", 73}, args)
 }
@@ -1134,7 +1133,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesZeroValues_Pointer() 
 		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{73, "test", "", 73}, args)
 }
@@ -1160,7 +1159,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesZeroValues_PointerNil
 		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
-	s.True(errors.Is(err, ErrNoFields))
+	s.Require().ErrorIs(err, ErrNoFields)
 	s.Empty(sqlStr)
 	s.Empty(args)
 }
@@ -1186,7 +1185,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues() {
 		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{nil, nil, nil, 1}, args)
 }
@@ -1212,7 +1211,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_Pointer() {
 		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{nil, nil, nil, 1}, args)
 }
@@ -1238,7 +1237,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_PointerWith
 		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{73, "test", nil, 1}, args)
 }
@@ -1264,7 +1263,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_PointerWith
 		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{0, "test", nil, 1}, args)
 }
@@ -1290,7 +1289,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_PointerWith
 		WithIncludeNilValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{0, nil, nil, 1}, args)
 }
@@ -1317,7 +1316,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{nil, "", nil, 1}, args)
 }
@@ -1344,7 +1343,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{nil, "", nil, 1}, args)
 }
@@ -1371,7 +1370,7 @@ func (s *generateSQLSuite) TestGenerateSQL_Success_IncludesNilValues_IncludesZer
 		WithIncludeZeroValues(true),
 		WithWhere(mw),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("UPDATE test_table\nSET id = ?, name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{73, "", nil, 1}, args)
 }
@@ -1401,7 +1400,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success() {
 	}
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.NotNil(patch)
 	s.Equal([]string{"id = ?", "name = ?"}, patch.fields)
@@ -1425,7 +1424,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_StructOpt_IncludeNilF
 	}
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.NotNil(patch)
 	s.Equal([]string{"id = ?", "name = ?"}, patch.fields)
@@ -1449,7 +1448,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_StructOpt_IncludeZero
 	}
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.NotNil(patch)
 	s.Equal([]string{"id = ?", "name = ?"}, patch.fields)
@@ -1476,7 +1475,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_singleFieldUpdated() 
 	}
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.NotNil(patch)
 	s.Equal([]string{"name = ?"}, patch.fields)
@@ -1531,10 +1530,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{"test2", 18}, args)
@@ -1563,10 +1562,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_ValueField() {
 	mw.On("Where").Return("age = ?", []any{18})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET name = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{"test2", 18}, args)
@@ -1595,10 +1594,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_ValueFieldUpda
 	mw.On("Where").Return("age = ?", []any{18})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET name = ?, desc = ?\nWHERE (1=1)\nAND (\nage = ?\n)", sqlStr)
 	s.Equal([]any{"test2", "desc2", 18}, args)
@@ -1627,10 +1626,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeZeroVal
 	mw.On("Where").Return("id = ?", []any{73})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues(true))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{"test2", "", 73}, args)
@@ -1662,10 +1661,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeZeroVal
 	mw.On("Where").Return("id = ?", []any{73})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues(true))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET name = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{"test2", "", 73}, args)
@@ -1694,7 +1693,7 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeZeroVal
 	mw.On("Where").Return("id = ?", []any{1})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeZeroValues(true))
-	s.True(errors.Is(err, ErrNoChanges))
+	s.Require().ErrorIs(err, ErrNoChanges)
 	s.Nil(patch)
 }
 
@@ -1721,10 +1720,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw.On("Where").Return("id = ?", []any{1})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET id = ?, description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{nil, nil, 1}, args)
@@ -1753,10 +1752,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw.On("Where").Return("id = ?", []any{1})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{nil, 1}, args)
@@ -1785,10 +1784,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw.On("Where").Return("id = ?", []any{1})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET description = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{"", 1}, args)
@@ -1820,10 +1819,10 @@ func (s *NewDiffSQLPatchSuite) TestNewDiffSQLPatch_Success_SqlGen_IncludeNilValu
 	mw.On("Where").Return("id = ?", []any{1})
 
 	patch, err := NewDiffSQLPatch(&obj, &obj2, WithTable("test_table"), WithWhere(mw), WithIncludeNilValues(true), WithIncludeZeroValues(true))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sqlStr, args, err := patch.GenerateSQL()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("UPDATE test_table\nSET description = ?, addr = ?\nWHERE (1=1)\nAND (\nid = ?\n)", sqlStr)
 	s.Equal([]any{"", nil, 1}, args)


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes updates to the `.golangci.yaml` configuration file and multiple test files to enhance code quality and consistency. The primary changes involve adding a new linter and updating test assertions to use the `require` package for better error handling.

### Configuration Updates:
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R16): Added `testifylint` to the list of enabled linters and configured it to enable all rules. [[1]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R16) [[2]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R146-R147)

### Test Enhancements:
* [`inserter/sql_test.go`](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L165-R166): Updated test assertions to use `s.Require()` instead of `s.NoError()` and `s.Len()` for more consistent and immediate test failures. [[1]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L165-R166) [[2]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L184-R192) [[3]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L219-R220) [[4]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L247-R247) [[5]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L269-R269) [[6]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L291-R291) [[7]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L310-R310) [[8]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L330-R338) [[9]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L360-R368) [[10]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L388-R388) [[11]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L407-R407) [[12]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L431-R431) [[13]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L457-R457) [[14]](diffhunk://#diff-d54851d438f801ca655964fe8523e00e7a08b8f1e11efb719b1573e7b6a07345L486-R486)

* [`loader_test.go`](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L46-R46): Similar updates were made to use `s.Require()` instead of `s.NoError()` and `s.Error()` across various test cases to ensure immediate and clear test failures. [[1]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L46-R46) [[2]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L68-R68) [[3]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L90-R90) [[4]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L112-R112) [[5]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L134-R134) [[6]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L156-R156) [[7]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L175-R175) [[8]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L196-R196) [[9]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L221-R221) [[10]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L252-R252) [[11]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L284-R284) [[12]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L316-R316) [[13]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L347-R347) [[14]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L384-R384) [[15]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L423-R423) [[16]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L454-R454) [[17]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L482-R482) [[18]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L519-R519) [[19]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L543-R543) [[20]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L569-R569) [[21]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L591-R591) [[22]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L624-R624) [[23]](diffhunk://#diff-4c743ecf2cd45e558643f774ff7c6581328a6807bb125951d4feaa5e1954ac26L646-R646)