### PR TITLE
feat(cicd): adding perfsprint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - tparallel
     - intrange
     - testifylint
+    - perfsprint
 issues:
   exclude-rules:
     - path: (.+)_test.go


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `.golangci.yaml` file. The change adds a new linter to the list of linters.

* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R17): Added `perfsprint` to the list of linters.